### PR TITLE
feat: build searchable history record

### DIFF
--- a/src/api/getSearchableHistory.ts
+++ b/src/api/getSearchableHistory.ts
@@ -1,0 +1,50 @@
+import { SearchableChatHistories } from '../types';
+import {
+  CONVERSATION_MESSAGES_STORE_NAME,
+  CONVERSATION_STORE_NAME,
+  idbDatabase,
+} from './idb';
+import { mergeTitleAndMessages } from './mergeTitleAndMessages';
+
+export async function getSearchableHistory(): Promise<SearchableChatHistories | null> {
+  const db = await idbDatabase();
+
+  const txMessages = db.transaction(
+    CONVERSATION_MESSAGES_STORE_NAME,
+    'readonly',
+  );
+  const txConversations = db.transaction(CONVERSATION_STORE_NAME, 'readonly');
+
+  const storeMessages = txMessages.objectStore(
+    CONVERSATION_MESSAGES_STORE_NAME,
+  );
+  const storeConversations = txConversations.objectStore(
+    CONVERSATION_STORE_NAME,
+  );
+
+  const messagesRequest = storeMessages.getAll();
+  const conversationsRequest = storeConversations.getAll();
+
+  return new Promise((resolve, reject) => {
+    messagesRequest.addEventListener('success', () => {
+      conversationsRequest.addEventListener('success', () => {
+        if (messagesRequest.result && conversationsRequest.result) {
+          resolve(
+            mergeTitleAndMessages(
+              messagesRequest.result,
+              conversationsRequest.result,
+            ),
+          );
+        } else {
+          resolve(null);
+        }
+      });
+    });
+    messagesRequest.addEventListener('error', () =>
+      reject(new Error('indexedDB: failed to fetch all conversation messages')),
+    );
+    conversationsRequest.addEventListener('error', () =>
+      reject(new Error('indexedDB: failed to fetch all conversations')),
+    );
+  });
+}

--- a/src/api/mergeTitleAndMessages.test.ts
+++ b/src/api/mergeTitleAndMessages.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { ChatMessage, ConversationHistory, MessageHistory } from '../types';
+import { mergeTitleAndMessages } from './mergeTitleAndMessages';
+
+describe('mergeTitleAndMessages', () => {
+  const messagesData: { id: string; messages: ChatMessage[] }[] = [
+    {
+      id: '123',
+      messages: [
+        { role: 'user', content: 'Hello AI' },
+        { role: 'assistant', content: 'Hello World!' },
+      ],
+    },
+    {
+      id: '456',
+      messages: [
+        { role: 'user', content: 'foobar' },
+        { role: 'assistant', content: 'fizzbuzz' },
+      ],
+    },
+  ];
+
+  const conversationsData: ConversationHistory[] = [
+    {
+      id: '123',
+      title: 'Chat 1',
+      tokensRemaining: 10000,
+      lastSaved: 987654321,
+      model: 'gpt-4o',
+    },
+    {
+      id: '456',
+      title: 'Chat 2',
+      tokensRemaining: 10000,
+      lastSaved: 987654321,
+      model: 'gpt-4o',
+    },
+  ];
+
+  it('should correctly merge titles with their messages', () => {
+    const result = mergeTitleAndMessages(messagesData, conversationsData);
+    expect(result).toEqual({
+      '123': {
+        title: 'Chat 1',
+        messages: [
+          { role: 'user', content: 'Hello AI' },
+          { role: 'assistant', content: 'Hello World!' },
+        ],
+      },
+      '456': {
+        title: 'Chat 2',
+        messages: [
+          { role: 'user', content: 'foobar' },
+          { role: 'assistant', content: 'fizzbuzz' },
+        ],
+      },
+    });
+  });
+
+  it('should handle cases where there are no messages for a conversation', () => {
+    //  Missing the '456' entry
+    const singularConversationData: ConversationHistory[] = [
+      {
+        id: '123',
+        title: 'Chat 1',
+        tokensRemaining: 10000,
+        lastSaved: 987654321,
+        model: 'gpt-4o',
+      },
+    ];
+
+    const result = mergeTitleAndMessages(
+      messagesData,
+      singularConversationData,
+    );
+    expect(result).toEqual({
+      '123': {
+        title: 'Chat 1',
+        messages: [
+          { role: 'user', content: 'Hello AI' },
+          { role: 'assistant', content: 'Hello World!' },
+        ],
+      },
+    });
+  });
+
+  it('should handle an empty input gracefully', () => {
+    const emptyMessages: MessageHistory[] = [];
+    const emptyConversations: ConversationHistory[] = [];
+
+    const result = mergeTitleAndMessages(emptyMessages, emptyConversations);
+    expect(result).toEqual({});
+  });
+});

--- a/src/api/mergeTitleAndMessages.ts
+++ b/src/api/mergeTitleAndMessages.ts
@@ -1,0 +1,37 @@
+import {
+  ChatMessage,
+  ConversationHistory,
+  MessageHistory,
+  SearchableChatHistories,
+} from '../types';
+
+/**
+ * Merges conversation data with their respective messages, excluding conversations without messages.
+ * @param messageHistory - Array of objects containing conversation IDs and their messages.
+ * @param conversationHistory - Array of objects containing conversation IDs and their titles (and other metadata).
+ * @returns An object indexed by conversation ID containing titles and associated messages to be used in search.
+ */
+export function mergeTitleAndMessages(
+  messageHistory: MessageHistory[],
+  conversationHistory: ConversationHistory[],
+): SearchableChatHistories {
+  //  Build the map of conversation IDs to the that conversation's messages
+  const messagesMap = messageHistory.reduce<Record<string, ChatMessage[]>>(
+    (acc, entry) => {
+      acc[entry.id] = entry.messages;
+      return acc;
+    },
+    {},
+  );
+
+  //  Add the titles to the map so we can load/search all conversation text
+  return conversationHistory.reduce<SearchableChatHistories>((acc, entry) => {
+    if (messagesMap[entry.id]) {
+      acc[entry.id] = {
+        title: entry.title,
+        messages: messagesMap[entry.id],
+      };
+    }
+    return acc;
+  }, {});
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,10 @@ export type ChatMessage =
   | ChatCompletionMessageParam
   | ChatCompletionToolMessageParam
   | ChatCompletionAssistantMessageParam;
+
+export type MessageHistory = { id: string; messages: ChatMessage[] };
+
+export type SearchableChatHistories = Record<
+  string,
+  { title: string; messages: ChatMessage[] }
+>;


### PR DESCRIPTION
We currently store conversation history with all metadata, but not the messages (too much data to load just to render the titles for selecting previous conversations).

However, if we want the user to be able to search through messages _and_ titles simultaneously, then we need an object of this shape

```
id: string;
title: string;
messages: ChatMessages[]
```