### PR TITLE
refactor: contain search modal state to sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { ChatInterface } from './ChatInterface';
 export const App = () => {
   const [isMobileSideBarOpen, setIsMobileSideBarOpen] = useState(false);
   const [isDesktopSideBarOpen, setIsDesktopSideBarOpen] = useState(true);
-  const [isSearchHistoryOpen, setIsSearchHistoryOpen] = useState(false);
 
   const openMobileSideBar = () => {
     setIsMobileSideBarOpen(true);
@@ -40,8 +39,6 @@ export const App = () => {
         isDesktopSideBarOpen={isDesktopSideBarOpen}
         onMobileCloseClick={() => setIsMobileSideBarOpen(false)}
         onDesktopCloseClick={() => setIsDesktopSideBarOpen(false)}
-        isSearchHistoryOpen={isSearchHistoryOpen}
-        onClickSearchHistory={() => setIsSearchHistoryOpen(true)}
       />
       <ChatInterface
         activeChat={activeChat}

--- a/src/SideBar.test.tsx
+++ b/src/SideBar.test.tsx
@@ -4,44 +4,20 @@ import { SideBar, SideBarProps } from './SideBar';
 import { useIsMobileLayout } from './theme/useIsMobileLayout';
 
 vi.mock('./MobileSideBar', () => ({
-  MobileSideBar: ({
-    onCloseClick,
-    onClickSearchHistory,
-  }: {
-    onCloseClick: () => void;
-    onClickSearchHistory: () => void;
-  }) => (
+  MobileSideBar: ({ onCloseClick }: { onCloseClick: () => void }) => (
     <div>
       <button data-testid="mobile-sidebar-close" onClick={onCloseClick}>
         Mobile Close
-      </button>
-      <button
-        data-testid="mobile-search-history"
-        onClick={onClickSearchHistory}
-      >
-        Mobile Search
       </button>
     </div>
   ),
 }));
 
 vi.mock('./DesktopSideBar', () => ({
-  DesktopSideBar: ({
-    onCloseClick,
-    onClickSearchHistory,
-  }: {
-    onCloseClick: () => void;
-    onClickSearchHistory: () => void;
-  }) => (
+  DesktopSideBar: ({ onCloseClick }: { onCloseClick: () => void }) => (
     <div>
       <button data-testid="desktop-sidebar-close" onClick={onCloseClick}>
         Desktop Close
-      </button>
-      <button
-        data-testid="desktop-search-history"
-        onClick={onClickSearchHistory}
-      >
-        Desktop Search
       </button>
     </div>
   ),
@@ -60,10 +36,8 @@ describe('SideBar', () => {
     onUpdateConversationTitle: vi.fn(),
     onDesktopCloseClick: vi.fn(),
     onMobileCloseClick: vi.fn(),
-    onClickSearchHistory: vi.fn(),
     isMobileSideBarOpen: false,
     isDesktopSideBarOpen: true,
-    isSearchHistoryOpen: false,
   };
 
   beforeEach(() => {
@@ -237,23 +211,5 @@ describe('SideBar', () => {
 
     screen.getByTestId('desktop-sidebar-close').click();
     expect(mockProps.onDesktopCloseClick).toHaveBeenCalledTimes(1);
-  });
-
-  test('calls onClickSearchHistory when mobile search history button is clicked', () => {
-    vi.mocked(useIsMobileLayout).mockReturnValue(true);
-
-    render(<SideBar {...mockProps} isMobileSideBarOpen={true} />);
-
-    screen.getByTestId('mobile-search-history').click();
-    expect(mockProps.onClickSearchHistory).toHaveBeenCalledTimes(1);
-  });
-
-  test('calls onClickSearchHistory when desktop search history button is clicked', () => {
-    vi.mocked(useIsMobileLayout).mockReturnValue(false);
-
-    render(<SideBar {...mockProps} isDesktopSideBarOpen={true} />);
-
-    screen.getByTestId('desktop-search-history').click();
-    expect(mockProps.onClickSearchHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -5,6 +5,7 @@ import { DesktopSideBar } from './DesktopSideBar';
 import { ChatHistory } from './ChatHistory';
 import { useIsMobileLayout } from './theme/useIsMobileLayout';
 import { ConversationHistories } from './types';
+import { useState } from 'react';
 
 export interface SideBarProps {
   conversationHistories: ConversationHistories;
@@ -16,8 +17,6 @@ export interface SideBarProps {
   onMobileCloseClick: () => void;
   isMobileSideBarOpen: boolean;
   isDesktopSideBarOpen: boolean;
-  isSearchHistoryOpen: boolean;
-  onClickSearchHistory: () => void;
 }
 
 export const SideBar = ({
@@ -30,9 +29,9 @@ export const SideBar = ({
   onDesktopCloseClick,
   isMobileSideBarOpen,
   isDesktopSideBarOpen,
-  isSearchHistoryOpen,
-  onClickSearchHistory,
 }: SideBarProps) => {
+  const [isSearchHistoryOpen, setIsSearchHistoryOpen] = useState(false);
+
   const isMobileLayout = useIsMobileLayout();
   const showMobileSideBar = isMobileLayout && isMobileSideBarOpen;
   const showDesktopSideBar = !isMobileLayout && isDesktopSideBarOpen;
@@ -45,14 +44,14 @@ export const SideBar = ({
           {showMobileSideBar && (
             <MobileSideBar
               isSearchHistoryOpen={isSearchHistoryOpen}
-              onClickSearchHistory={onClickSearchHistory}
+              onClickSearchHistory={() => setIsSearchHistoryOpen(true)}
               onCloseClick={onMobileCloseClick}
             />
           )}
           {showDesktopSideBar && (
             <DesktopSideBar
               isSearchHistoryOpen={isSearchHistoryOpen}
-              onClickSearchHistory={onClickSearchHistory}
+              onClickSearchHistory={() => setIsSearchHistoryOpen(true)}
               onCloseClick={onDesktopCloseClick}
             />
           )}


### PR DESCRIPTION
Rather than triggering app wide re-renders when a user opens & closes the search modal (by managing that state in `App.tsx`, let's contain that state within the sidebar component, and it can pass it to the mobile & desktop children.