### PR TITLE
fix: include lastSaved in searchable history

### DIFF
--- a/src/SideBar.test.tsx
+++ b/src/SideBar.test.tsx
@@ -247,10 +247,12 @@ describe('SideBar', () => {
     const mockHistory: SearchableChatHistories = {
       conversation1: {
         title: 'First Conversation',
+        lastSaved: 123400000000,
         messages: [{ role: 'user', content: 'Hello' }],
       },
       conversation2: {
         title: 'Second Conversation',
+        lastSaved: 987860000000,
         messages: [
           { role: 'user', content: 'Can you help me?' },
           { role: 'assistant', content: 'Yes of course!' },

--- a/src/api/mergeTitleAndMessages.test.ts
+++ b/src/api/mergeTitleAndMessages.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { ChatMessage, ConversationHistory, MessageHistory } from '../types';
+import { ConversationHistory, MessageHistory } from '../types';
 import { mergeTitleAndMessages } from './mergeTitleAndMessages';
 
 describe('mergeTitleAndMessages', () => {
-  const messagesData: { id: string; messages: ChatMessage[] }[] = [
+  const messagesData: MessageHistory[] = [
     {
       id: '123',
       messages: [
@@ -42,6 +42,7 @@ describe('mergeTitleAndMessages', () => {
     expect(result).toEqual({
       '123': {
         title: 'Chat 1',
+        lastSaved: 987654321,
         messages: [
           { role: 'user', content: 'Hello AI' },
           { role: 'assistant', content: 'Hello World!' },
@@ -49,6 +50,7 @@ describe('mergeTitleAndMessages', () => {
       },
       '456': {
         title: 'Chat 2',
+        lastSaved: 987654321,
         messages: [
           { role: 'user', content: 'foobar' },
           { role: 'assistant', content: 'fizzbuzz' },
@@ -76,6 +78,7 @@ describe('mergeTitleAndMessages', () => {
     expect(result).toEqual({
       '123': {
         title: 'Chat 1',
+        lastSaved: 987654321,
         messages: [
           { role: 'user', content: 'Hello AI' },
           { role: 'assistant', content: 'Hello World!' },

--- a/src/api/mergeTitleAndMessages.ts
+++ b/src/api/mergeTitleAndMessages.ts
@@ -30,6 +30,7 @@ export function mergeTitleAndMessages(
       acc[entry.id] = {
         title: entry.title,
         messages: messagesMap[entry.id],
+        lastSaved: entry.lastSaved,
       };
     }
     return acc;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,5 +40,5 @@ export type MessageHistory = { id: string; messages: ChatMessage[] };
 
 export type SearchableChatHistories = Record<
   string,
-  { title: string; messages: ChatMessage[] }
+  { title: string; messages: ChatMessage[]; lastSaved: number }
 >;


### PR DESCRIPTION
Since we need to order search histories by date, let's include the timestamp in this data shape