### PR TITLE
feat: search history (pt. 2)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export type ConversationHistory = {
   tokensRemaining: number;
 };
 
+export type GroupedConversations = Record<string, ConversationHistory[]>;
+
 export type ConversationHistories = Record<string, ConversationHistory>;
 
 export type ChatMessage =
@@ -36,9 +38,18 @@ export type ChatMessage =
   | ChatCompletionToolMessageParam
   | ChatCompletionAssistantMessageParam;
 
+//  type returned from the conversation messages store
 export type MessageHistory = { id: string; messages: ChatMessage[] };
 
-export type SearchableChatHistories = Record<
-  string,
-  { title: string; messages: ChatMessage[]; lastSaved: number }
->;
+//  we need to be able to search all text and sort by time
+export type SearchableChatHistory = {
+  title: string;
+  messages: ChatMessage[];
+  lastSaved: number;
+};
+
+//  type returned from getSearchableHistory
+export type SearchableChatHistories = Record<string, SearchableChatHistory>;
+
+//  Record of searchable histories, indexed by the time group (Today, Yesterday, etc.)
+export type GroupedSearchHistories = Record<string, SearchableChatHistory[]>;

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -160,36 +160,35 @@ describe('formatConversationTitle', () => {
 });
 
 describe('groupAndFilterConversations', () => {
-  let mockSearchHistories: SearchableChatHistories;
   const now = new Date('2024-02-13T12:00:00Z').getTime();
+
+  const mockSearchHistories: SearchableChatHistories = {
+    1: {
+      title: 'Bitcoin Discussion',
+      lastSaved: now - 1000 * 60 * 60 * 2,
+      messages: [{ role: 'user', content: 'Can I have bitcoin advice?' }],
+    },
+    2: {
+      title: 'Ethereum Chat',
+      lastSaved: now - 1000 * 60 * 60 * 25,
+      messages: [{ role: 'user', content: 'Where can I buy ETH?' }],
+    },
+    3: {
+      title: 'Blockchain Overview',
+      lastSaved: now - 1000 * 60 * 60 * 24 * 5,
+      messages: [
+        { role: 'user', content: 'What is the history of blockchain?' },
+      ],
+    },
+    4: {
+      title: 'Party planning tips',
+      lastSaved: now - 1000 * 60 * 60 * 24 * 6,
+      messages: [{ role: 'user', content: 'I need help planning.' }],
+    },
+  };
 
   beforeEach(() => {
     vi.spyOn(Date.prototype, 'getTime').mockImplementation(() => now);
-
-    mockSearchHistories = {
-      1: {
-        title: 'Bitcoin Discussion',
-        lastSaved: now - 1000 * 60 * 60 * 2,
-        messages: [{ role: 'user', content: 'Can I have bitcoin advice?' }],
-      },
-      2: {
-        title: 'Ethereum Chat',
-        lastSaved: now - 1000 * 60 * 60 * 25,
-        messages: [{ role: 'user', content: 'Where can I buy ETH?' }],
-      },
-      3: {
-        title: 'Blockchain Overview',
-        lastSaved: now - 1000 * 60 * 60 * 24 * 5,
-        messages: [
-          { role: 'user', content: 'What is the history of blockchain?' },
-        ],
-      },
-      4: {
-        title: 'Party planning tips',
-        lastSaved: now - 1000 * 60 * 60 * 24 * 6,
-        messages: [{ role: 'user', content: 'I need help planning.' }],
-      },
-    };
   });
 
   afterEach(() => {

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -166,25 +166,6 @@ describe('groupAndFilterConversations', () => {
   beforeEach(() => {
     vi.spyOn(Date.prototype, 'getTime').mockImplementation(() => now);
 
-    // const mockConversation: ChatMessage[] = [
-    //   {
-    //     role: 'system',
-    //     content: 'System prompt that should be ignored',
-    //   },
-    //   {
-    //     role: 'user',
-    //     content: 'First user message',
-    //   },
-    //   {
-    //     role: 'assistant',
-    //     content: 'First assistant response with searchable content',
-    //   },
-    //   {
-    //     role: 'user',
-    //     content: 'Second user message with different content',
-    //   },
-    // ];
-
     mockSearchHistories = {
       1: {
         title: 'Bitcoin Discussion',

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -233,6 +233,11 @@ describe('groupAndFilterConversations', () => {
     expect(filtered['Yesterday'][0].title).toBe('Ethereum Chat');
   });
 
+  it('handles missing search', () => {
+    const filtered = groupAndFilterConversations(mockSearchHistories, '1');
+    expect(filtered).toStrictEqual({});
+  });
+
   it('should return conversations from the correct time groups and remove any empty groups', () => {
     const filtered = groupAndFilterConversations(
       mockSearchHistories,

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -227,6 +227,12 @@ describe('groupAndFilterConversations', () => {
     expect(filtered['Last week'][1].title).toBe('Party planning tips');
   });
 
+  it('handles multiple content matches', () => {
+    const filtered = groupAndFilterConversations(mockSearchHistories, 'can');
+    expect(filtered['Today'][0].title).toBe('Bitcoin Discussion');
+    expect(filtered['Yesterday'][0].title).toBe('Ethereum Chat');
+  });
+
   it('should return conversations from the correct time groups and remove any empty groups', () => {
     const filtered = groupAndFilterConversations(
       mockSearchHistories,

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -5,11 +5,7 @@ import {
   groupAndFilterConversations,
   groupConversationsByTime,
 } from './helpers';
-import {
-  ChatMessage,
-  ConversationHistories,
-  SearchableChatHistories,
-} from '../types';
+import { ConversationHistories, SearchableChatHistories } from '../types';
 
 describe('getTimeGroup', () => {
   beforeEach(() => {
@@ -170,40 +166,47 @@ describe('groupAndFilterConversations', () => {
   beforeEach(() => {
     vi.spyOn(Date.prototype, 'getTime').mockImplementation(() => now);
 
-    const mockConversation: ChatMessage[] = [
-      {
-        role: 'system',
-        content: 'System prompt that should be ignored',
-      },
-      {
-        role: 'user',
-        content: 'First user message',
-      },
-      {
-        role: 'assistant',
-        content: 'First assistant response with searchable content',
-      },
-      {
-        role: 'user',
-        content: 'Second user message with different content',
-      },
-    ];
+    // const mockConversation: ChatMessage[] = [
+    //   {
+    //     role: 'system',
+    //     content: 'System prompt that should be ignored',
+    //   },
+    //   {
+    //     role: 'user',
+    //     content: 'First user message',
+    //   },
+    //   {
+    //     role: 'assistant',
+    //     content: 'First assistant response with searchable content',
+    //   },
+    //   {
+    //     role: 'user',
+    //     content: 'Second user message with different content',
+    //   },
+    // ];
 
     mockSearchHistories = {
       1: {
         title: 'Bitcoin Discussion',
         lastSaved: now - 1000 * 60 * 60 * 2,
-        messages: mockConversation,
+        messages: [{ role: 'user', content: 'Can I have bitcoin advice?' }],
       },
       2: {
         title: 'Ethereum Chat',
         lastSaved: now - 1000 * 60 * 60 * 25,
-        messages: mockConversation,
+        messages: [{ role: 'user', content: 'Where can I buy ETH?' }],
       },
       3: {
         title: 'Blockchain Overview',
         lastSaved: now - 1000 * 60 * 60 * 24 * 5,
-        messages: mockConversation,
+        messages: [
+          { role: 'user', content: 'What is the history of blockchain?' },
+        ],
+      },
+      4: {
+        title: 'Party planning tips',
+        lastSaved: now - 1000 * 60 * 60 * 24 * 6,
+        messages: [{ role: 'user', content: 'I need help planning.' }],
       },
     };
   });
@@ -222,25 +225,25 @@ describe('groupAndFilterConversations', () => {
   });
 
   it('should be case insensitive when filtering', () => {
-    const filtered = groupAndFilterConversations(
-      mockSearchHistories,
-      'BITCOIN',
-    );
+    const filtered = groupAndFilterConversations(mockSearchHistories, 'ADVICE');
     expect(filtered['Today'][0].title).toBe('Bitcoin Discussion');
   });
 
   it('should handle partial matches', () => {
-    const filtered = groupAndFilterConversations(mockSearchHistories, 'block');
+    const filtered = groupAndFilterConversations(
+      mockSearchHistories,
+      '  block',
+    );
     expect(filtered['Last week'][0].title).toBe('Blockchain Overview');
   });
 
   it('should return all conversations when search term is empty', () => {
     const filtered = groupAndFilterConversations(mockSearchHistories, '');
-    expect(Object.keys(filtered)).toStrictEqual([
-      'Today',
-      'Yesterday',
-      'Last week',
-    ]);
+
+    expect(filtered['Today'][0].title).toBe('Bitcoin Discussion');
+    expect(filtered['Yesterday'][0].title).toBe('Ethereum Chat');
+    expect(filtered['Last week'][0].title).toBe('Blockchain Overview');
+    expect(filtered['Last week'][1].title).toBe('Party planning tips');
   });
 
   it('should return conversations from the correct time groups and remove any empty groups', () => {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -126,23 +126,19 @@ export const groupAndFilterConversations = (
   if (!conversations) return groupedFilteredResults;
 
   const isSearching = searchTerm.trim() !== '';
+  const searchRegex = isSearching ? new RegExp(searchTerm.trim(), 'i') : null;
 
   Object.values(conversations).forEach((conversation) => {
-    // If we aren't searching, return all histories, sorted by time
-    if (isSearching) {
-      //  Remove whitespace and lowercase
-      const lowercaseSearchTerm = searchTerm.trim().toLowerCase();
-
+    //  If we aren't searching, return all histories, sorted by time
+    if (isSearching && searchRegex) {
       //  Primary search is for title match
-      const titleMatches = conversation.title
-        .toLowerCase()
-        .includes(lowercaseSearchTerm);
+      const titleMatches = searchRegex.test(conversation.title);
 
       //  Secondary search is for content matches
       if (!titleMatches) {
         const messageMatches = conversation.messages.some((message) => {
           const textContent = extractTextContent(message);
-          return textContent.toLowerCase().includes(lowercaseSearchTerm);
+          return searchRegex.test(textContent);
         });
 
         //  if we haven't found any title or content matches, return (triggers 'No results')

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -76,12 +76,6 @@ export const formatConversationTitle = (title: string, maxLength: number) => {
   return formattedTitle;
 };
 
-export const deepCopy = <T>(obj: T) => {
-  return window.structuredClone
-    ? window.structuredClone(obj)
-    : JSON.parse(JSON.stringify(obj));
-};
-
 export const getERC20Record = (
   denom: string,
   records: Record<string, ERC20Record>,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -134,7 +134,7 @@ export const groupAndFilterConversations = (
   const isSearching = searchTerm.trim() !== '';
 
   Object.values(conversations).forEach((conversation) => {
-    // If we aren't searching, we returned all histories, sorted
+    // If we aren't searching, return all histories, sorted by time
     if (isSearching) {
       //  Remove whitespace and lowercase
       const lowercaseSearchTerm = searchTerm.trim().toLowerCase();
@@ -166,10 +166,10 @@ export const groupAndFilterConversations = (
     groupedFilteredResults[timeGroup].push(conversation);
   });
 
-  for (const group in groupedFilteredResults) {
+  for (const tGroup in groupedFilteredResults) {
     //  Only sort if the group has more than one entry
-    if (groupedFilteredResults[group].length > 1) {
-      groupedFilteredResults[group].sort((a, b) => b.lastSaved - a.lastSaved);
+    if (groupedFilteredResults[tGroup].length > 1) {
+      groupedFilteredResults[tGroup].sort((a, b) => b.lastSaved - a.lastSaved);
     }
   }
 


### PR DESCRIPTION
- implement helper for filtering by searching term and grouping by time
- different from Kava Chat implementation since
   - conversations and messages are stored separately
   - in order to search all text and filter by time, we need a custom, lightweight data structure that is loaded only when the search modal is open
