### PR TITLE
feat: search history (pt. 3)

### DIFF
--- a/src/ModalWrapper.tsx
+++ b/src/ModalWrapper.tsx
@@ -1,0 +1,52 @@
+import styles from './SearchHistoryModal.module.css';
+import ReactDOM from 'react-dom';
+import ButtonIcon from './ButtonIcon';
+import { X } from 'lucide-react';
+import { ReactNode, RefObject, useEffect } from 'react';
+
+interface ModalWrapperProps {
+  children: ReactNode;
+  modalRef: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+  closeOnOutsideClick?: boolean;
+}
+
+export const ModalWrapper = ({
+  children,
+  modalRef,
+  onClose,
+  closeOnOutsideClick = true,
+}: ModalWrapperProps) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        closeOnOutsideClick &&
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [closeOnOutsideClick, onClose, modalRef]);
+
+  return ReactDOM.createPortal(
+    <div className={styles.modalOverlay}>
+      <div className={styles.modal} ref={modalRef}>
+        <ButtonIcon
+          className={`${styles.iconButton} ${styles.closeButton}`}
+          icon={X}
+          aria-label="Close search modal"
+          onClick={onClose}
+        />
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/src/SearchHistoryModal.module.css
+++ b/src/SearchHistoryModal.module.css
@@ -1,0 +1,172 @@
+.container {
+  position: relative;
+}
+
+.iconButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--borderRadius-sm);
+  transition: color 0.2s ease;
+}
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--colors-bgSecondary);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  z-index: 9999;
+  pointer-events: auto;
+}
+
+.modal {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  border-radius: 0;
+  border: none;
+  top: 0;
+  background-color: var(--colors-bgSecondary);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.closeButton {
+  position: static;
+  align-self: flex-end;
+  margin: var(--spacing-md) var(--spacing-md) 0;
+  display: flex;
+}
+
+.searchInputWrapper {
+  padding: var(--spacing-md);
+  position: relative;
+}
+
+.searchInput {
+  width: 100%;
+  height: 4rem;
+  background-color: var(--colors-bgTertiary);
+  border: none;
+  border-radius: var(--borderRadius-sm);
+  padding: 0 var(--spacing-md);
+  color: var(--colors-textPrimary);
+  padding-right: calc(var(--spacing-md) * 3);
+}
+
+.searchInput:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--colors-borderPrimary);
+}
+
+.results {
+  overflow-y: auto;
+  padding: var(--spacing-sm);
+  flex: 1;
+  min-height: 0;
+}
+
+.timeGroup {
+  margin-bottom: var(--spacing-md);
+}
+
+.timeGroupTitle {
+  margin: var(--spacing-sm) var(--spacing-sm);
+  color: var(--colors-textTertiary);
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.conversationItem {
+  padding: var(--spacing-sm) var(--spacing-sm);
+  cursor: pointer;
+  border-radius: var(--borderRadius-sm);
+}
+
+.conversationItem:hover {
+  background-color: var(--colors-bgTertiary);
+}
+
+.conversationTitle {
+  color: var(--colors-textPrimary);
+  font-size: 1.4rem;
+}
+
+.conversationSnippet {
+  font-size: 1.2rem;
+  color: var(--colors-textMuted);
+  line-height: 1.5;
+  word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: var(--spacing-xs);
+}
+
+.selected {
+  background-color: var(--colors-bgTertiary);
+}
+
+.noResults {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--colors-textTertiary);
+  font-size: 1.5rem;
+}
+
+.searchCloseIcon {
+  position: absolute;
+  right: var(--spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--colors-textMuted);
+  cursor: pointer;
+  padding: var(--spacing-sm);
+  height: 4rem;
+  width: 4rem;
+}
+
+.searchCloseIcon:hover {
+  color: var(--colors-textPrimary);
+  background-color: var(--colors-bgQuaternary);
+}
+
+@media (min-width: 768px) {
+
+  .modalOverlay {
+    background-color: rgba(0, 0, 0, 0.5);
+    align-items: center;
+  }
+
+  .modal {
+    width: 60rem;
+    height: 40rem;
+    max-width: 90vw;
+    border-radius: var(--borderRadius-md);
+    background-color: var(--colors-bgTertiary);
+    top: -5vh;
+  }
+
+  .closeButton {
+    display: none;
+  }
+
+  .searchInputWrapper {
+    border-bottom: 1px solid var(--colors-borderSecondary);
+  }
+}

--- a/src/SearchHistoryModal.module.css
+++ b/src/SearchHistoryModal.module.css
@@ -146,6 +146,10 @@
   background-color: var(--colors-bgQuaternary);
 }
 
+.hidden {
+  display: none;
+}
+
 @media (min-width: 768px) {
 
   .modalOverlay {

--- a/src/SearchHistoryModal.test.tsx
+++ b/src/SearchHistoryModal.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SearchHistoryModalBody } from './SearchHistoryModalBody';
+import { GroupedSearchHistories, SearchableChatHistory } from './types';
+
+describe('SearchHistoryModalBody', () => {
+  const onSelectConversation = vi.fn();
+  const handleSearchTermChange = vi.fn();
+  const onClose = vi.fn();
+
+  const props = {
+    onSelectConversation,
+    onClose,
+    handleSearchTermChange,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should select the only conversation when Enter key is pressed', () => {
+    const singleConversation: SearchableChatHistory = {
+      id: 'conv-123',
+      title: 'Test Conversation',
+      messages: [{ role: 'user', content: 'This is a test' }],
+      lastSaved: 1234000000,
+    };
+
+    const groupedConversations: GroupedSearchHistories = {
+      Today: [singleConversation],
+    };
+
+    render(
+      <SearchHistoryModalBody
+        {...props}
+        groupedConversations={groupedConversations}
+        inputValue="test"
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search conversations...');
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onSelectConversation).toHaveBeenCalledWith('conv-123');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should not select any conversation when Enter key is pressed with multiple results', () => {
+    const groupedConversations: GroupedSearchHistories = {
+      Today: [
+        {
+          id: 'conv-123',
+          title: 'First Conversation',
+          messages: [{ role: 'user', content: 'This is a test' }],
+          lastSaved: 1234000000,
+        },
+        {
+          id: 'conv-456',
+          title: 'Second Conversation',
+          messages: [{ role: 'user', content: 'This is a test' }],
+          lastSaved: 1234000001,
+        },
+      ],
+    };
+
+    render(
+      <SearchHistoryModalBody
+        {...props}
+        groupedConversations={groupedConversations}
+        inputValue="conversation"
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search conversations...');
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onSelectConversation).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should not select any conversation when Enter key is pressed with no results', () => {
+    const groupedConversations: GroupedSearchHistories = {};
+
+    render(
+      <SearchHistoryModalBody
+        {...props}
+        groupedConversations={groupedConversations}
+        inputValue="nonexistent"
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search conversations...');
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onSelectConversation).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should close the modal when Escape key is pressed', () => {
+    const groupedConversations: GroupedSearchHistories = {
+      Today: [
+        {
+          id: 'conv-123',
+          title: 'Test Conversation',
+          messages: [{ role: 'user', content: 'This is a test' }],
+          lastSaved: 1234000000,
+        },
+      ],
+    };
+
+    render(
+      <SearchHistoryModalBody
+        {...props}
+        groupedConversations={groupedConversations}
+        inputValue="test"
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search conversations...');
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/SearchHistoryModal.test.tsx
+++ b/src/SearchHistoryModal.test.tsx
@@ -4,6 +4,13 @@ import { SearchHistoryModalBody } from './SearchHistoryModalBody';
 import { GroupedSearchHistories, SearchableChatHistory } from './types';
 
 describe('SearchHistoryModalBody', () => {
+  const mockHistory: SearchableChatHistory = {
+    id: 'conv-123',
+    title: 'Test Conversation',
+    messages: [{ role: 'user', content: 'This is a test' }],
+    lastSaved: 1234000000,
+  };
+
   const onSelectConversation = vi.fn();
   const handleSearchTermChange = vi.fn();
   const onClose = vi.fn();
@@ -19,15 +26,8 @@ describe('SearchHistoryModalBody', () => {
   });
 
   it('should select the only conversation when Enter key is pressed', () => {
-    const singleConversation: SearchableChatHistory = {
-      id: 'conv-123',
-      title: 'Test Conversation',
-      messages: [{ role: 'user', content: 'This is a test' }],
-      lastSaved: 1234000000,
-    };
-
     const groupedConversations: GroupedSearchHistories = {
-      Today: [singleConversation],
+      Today: [mockHistory],
     };
 
     render(
@@ -49,17 +49,12 @@ describe('SearchHistoryModalBody', () => {
   it('should not select any conversation when Enter key is pressed with multiple results', () => {
     const groupedConversations: GroupedSearchHistories = {
       Today: [
-        {
-          id: 'conv-123',
-          title: 'First Conversation',
-          messages: [{ role: 'user', content: 'This is a test' }],
-          lastSaved: 1234000000,
-        },
+        mockHistory,
         {
           id: 'conv-456',
           title: 'Second Conversation',
-          messages: [{ role: 'user', content: 'This is a test' }],
           lastSaved: 1234000001,
+          messages: [{ role: 'user', content: 'hello?' }],
         },
       ],
     };
@@ -101,14 +96,7 @@ describe('SearchHistoryModalBody', () => {
 
   it('should close the modal when Escape key is pressed', () => {
     const groupedConversations: GroupedSearchHistories = {
-      Today: [
-        {
-          id: 'conv-123',
-          title: 'Test Conversation',
-          messages: [{ role: 'user', content: 'This is a test' }],
-          lastSaved: 1234000000,
-        },
-      ],
+      Today: [mockHistory],
     };
 
     render(

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -1,6 +1,6 @@
 import styles from './SearchHistoryModal.module.css';
 import { ModalWrapper } from './ModalWrapper';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { SearchHistoryModalBody } from './SearchHistoryModalBody';
 import { SearchableChatHistories } from './types';
 import { groupAndFilterConversations } from './utils/helpers';

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -1,0 +1,54 @@
+import styles from './SearchHistoryModal.module.css';
+import { ModalWrapper } from './ModalWrapper';
+import { useEffect, useRef, useState } from 'react';
+import { SearchHistoryModalBody } from './SearchHistoryModalBody';
+
+interface SearchHistoryProps {
+  isSearchHistoryOpen: boolean;
+  setIsSearchHistoryOpen: (i: boolean) => void;
+  setIsMobileSideBarOpen: (i: boolean) => void;
+}
+
+export const SearchHistoryModal = ({
+  isSearchHistoryOpen,
+  setIsSearchHistoryOpen,
+  setIsMobileSideBarOpen,
+}: SearchHistoryProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  //  todo - do we need this?
+  useEffect(() => {
+    if (isSearchHistoryOpen) {
+      // Focus input when modal opens
+      inputRef.current?.focus();
+      //  mobile sidebar is closed by default and that contains the component that mounts the search modal,
+      //  but if a user has opened chat history search from a larger screen, then we should update that so search modal
+      //  stays open on screen resize
+      setIsMobileSideBarOpen(true);
+    }
+  }, [isSearchHistoryOpen, setIsMobileSideBarOpen]);
+
+  const handleClose = () => {
+    setIsSearchHistoryOpen(false);
+    setSearchTerm('');
+  };
+  return (
+    <div className={styles.container}>
+      {isSearchHistoryOpen && (
+        <ModalWrapper modalRef={modalRef} onClose={handleClose}>
+          <SearchHistoryModalBody
+            conversations={[]}
+            onConversationSelect={() => ({})}
+            setIsOpen={setIsSearchHistoryOpen}
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            onClose={handleClose}
+          />
+        </ModalWrapper>
+      )}
+    </div>
+  );
+};

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -6,15 +6,17 @@ import { SearchableChatHistories } from './types';
 
 interface SearchHistoryProps {
   searchableHistory: SearchableChatHistories;
+  onSelectConversation: (id: string) => void;
   isSearchHistoryOpen: boolean;
-  setIsSearchHistoryOpen: (i: boolean) => void;
+  onCloseSearchHistory: () => void;
   setIsMobileSideBarOpen: (i: boolean) => void;
 }
 
 export const SearchHistoryModal = ({
   searchableHistory,
+  onSelectConversation,
   isSearchHistoryOpen,
-  setIsSearchHistoryOpen,
+  onCloseSearchHistory,
   setIsMobileSideBarOpen,
 }: SearchHistoryProps) => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -35,17 +37,17 @@ export const SearchHistoryModal = ({
   }, [isSearchHistoryOpen, setIsMobileSideBarOpen]);
 
   const handleClose = () => {
-    setIsSearchHistoryOpen(false);
+    onCloseSearchHistory();
     setSearchTerm('');
   };
+
   return (
     <div className={styles.container}>
       {isSearchHistoryOpen && (
         <ModalWrapper modalRef={modalRef} onClose={handleClose}>
           <SearchHistoryModalBody
             searchableHistory={searchableHistory}
-            onConversationSelect={() => ({})}
-            setIsOpen={setIsSearchHistoryOpen}
+            onSelectConversation={onSelectConversation}
             searchTerm={searchTerm}
             setSearchTerm={setSearchTerm}
             onClose={handleClose}

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -2,14 +2,17 @@ import styles from './SearchHistoryModal.module.css';
 import { ModalWrapper } from './ModalWrapper';
 import { useEffect, useRef, useState } from 'react';
 import { SearchHistoryModalBody } from './SearchHistoryModalBody';
+import { SearchableChatHistories } from './types';
 
 interface SearchHistoryProps {
+  searchableHistory: SearchableChatHistories;
   isSearchHistoryOpen: boolean;
   setIsSearchHistoryOpen: (i: boolean) => void;
   setIsMobileSideBarOpen: (i: boolean) => void;
 }
 
 export const SearchHistoryModal = ({
+  searchableHistory,
   isSearchHistoryOpen,
   setIsSearchHistoryOpen,
   setIsMobileSideBarOpen,
@@ -40,7 +43,7 @@ export const SearchHistoryModal = ({
       {isSearchHistoryOpen && (
         <ModalWrapper modalRef={modalRef} onClose={handleClose}>
           <SearchHistoryModalBody
-            conversations={[]}
+            searchableHistory={searchableHistory}
             onConversationSelect={() => ({})}
             setIsOpen={setIsSearchHistoryOpen}
             searchTerm={searchTerm}

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -8,14 +8,12 @@ import { groupAndFilterConversations } from './utils/helpers';
 interface SearchHistoryProps {
   searchableHistory: SearchableChatHistories;
   onSelectConversation: (id: string) => void;
-  isSearchHistoryOpen: boolean;
   onCloseSearchHistory: () => void;
 }
 
 export const SearchHistoryModal = ({
   searchableHistory,
   onSelectConversation,
-  isSearchHistoryOpen,
   onCloseSearchHistory,
 }: SearchHistoryProps) => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -37,17 +35,15 @@ export const SearchHistoryModal = ({
 
   return (
     <div className={styles.container}>
-      {isSearchHistoryOpen && (
-        <ModalWrapper modalRef={modalRef} onClose={handleClose}>
-          <SearchHistoryModalBody
-            inputValue={searchTerm}
-            groupedConversations={groupedConversations}
-            onSelectConversation={onSelectConversation}
-            handleSearchTermChange={handleSearchTermChange}
-            onClose={handleClose}
-          />
-        </ModalWrapper>
-      )}
+      <ModalWrapper modalRef={modalRef} onClose={handleClose}>
+        <SearchHistoryModalBody
+          inputValue={searchTerm}
+          groupedConversations={groupedConversations}
+          onSelectConversation={onSelectConversation}
+          handleSearchTermChange={handleSearchTermChange}
+          onClose={handleClose}
+        />
+      </ModalWrapper>
     </div>
   );
 };

--- a/src/SearchHistoryModal.tsx
+++ b/src/SearchHistoryModal.tsx
@@ -3,13 +3,13 @@ import { ModalWrapper } from './ModalWrapper';
 import { useEffect, useRef, useState } from 'react';
 import { SearchHistoryModalBody } from './SearchHistoryModalBody';
 import { SearchableChatHistories } from './types';
+import { groupAndFilterConversations } from './utils/helpers';
 
 interface SearchHistoryProps {
   searchableHistory: SearchableChatHistories;
   onSelectConversation: (id: string) => void;
   isSearchHistoryOpen: boolean;
   onCloseSearchHistory: () => void;
-  setIsMobileSideBarOpen: (i: boolean) => void;
 }
 
 export const SearchHistoryModal = ({
@@ -17,39 +17,33 @@ export const SearchHistoryModal = ({
   onSelectConversation,
   isSearchHistoryOpen,
   onCloseSearchHistory,
-  setIsMobileSideBarOpen,
 }: SearchHistoryProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const modalRef = useRef<HTMLDivElement>(null);
 
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  //  todo - do we need this?
-  useEffect(() => {
-    if (isSearchHistoryOpen) {
-      // Focus input when modal opens
-      inputRef.current?.focus();
-      //  mobile sidebar is closed by default and that contains the component that mounts the search modal,
-      //  but if a user has opened chat history search from a larger screen, then we should update that so search modal
-      //  stays open on screen resize
-      setIsMobileSideBarOpen(true);
-    }
-  }, [isSearchHistoryOpen, setIsMobileSideBarOpen]);
+  const handleSearchTermChange = (text: string) => {
+    setSearchTerm(text);
+  };
 
   const handleClose = () => {
     onCloseSearchHistory();
     setSearchTerm('');
   };
 
+  const groupedConversations = groupAndFilterConversations(
+    searchableHistory,
+    searchTerm,
+  );
+
   return (
     <div className={styles.container}>
       {isSearchHistoryOpen && (
         <ModalWrapper modalRef={modalRef} onClose={handleClose}>
           <SearchHistoryModalBody
-            searchableHistory={searchableHistory}
+            inputValue={searchTerm}
+            groupedConversations={groupedConversations}
             onSelectConversation={onSelectConversation}
-            searchTerm={searchTerm}
-            setSearchTerm={setSearchTerm}
+            handleSearchTermChange={handleSearchTermChange}
             onClose={handleClose}
           />
         </ModalWrapper>

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -3,26 +3,22 @@ import { useRef } from 'react';
 import { useIsMobileLayout } from './theme/useIsMobileLayout';
 import ButtonIcon from './ButtonIcon';
 import { X } from 'lucide-react';
-import { SearchableChatHistories } from './types';
-import {
-  formatContentSnippet,
-  formatConversationTitle,
-  groupAndFilterConversations,
-} from './utils/helpers';
+import { GroupedSearchHistories } from './types';
+import { formatContentSnippet, formatConversationTitle } from './utils/helpers';
 
 interface SearchModalBodyProps {
-  searchableHistory: SearchableChatHistories;
+  groupedConversations: GroupedSearchHistories;
   onSelectConversation: (id: string) => void;
-  searchTerm: string;
-  setSearchTerm: (searchTerm: string) => void;
+  handleSearchTermChange: (searchTerm: string) => void;
+  inputValue: string;
   onClose: () => void;
 }
 
 export const SearchHistoryModalBody = ({
-  searchableHistory,
+  groupedConversations,
   onSelectConversation,
-  searchTerm,
-  setSearchTerm,
+  handleSearchTermChange,
+  inputValue,
   onClose,
 }: SearchModalBodyProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -31,11 +27,6 @@ export const SearchHistoryModalBody = ({
       onClose();
     }
   };
-
-  const groupedConversations = groupAndFilterConversations(
-    searchableHistory,
-    searchTerm,
-  );
 
   const onHistoryItemClick = (id: string) => {
     onSelectConversation(id);
@@ -51,9 +42,10 @@ export const SearchHistoryModalBody = ({
           type="text"
           className={styles.searchInput}
           placeholder="Search conversations..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
+          value={inputValue}
+          onChange={(e) => handleSearchTermChange(e.target.value)}
           onKeyDown={handleKeyDown}
+          autoFocus
         />
         {/*Mobile design uses the close icon within ModalWrapper*/}
         {!isMobileLayout && (
@@ -92,7 +84,7 @@ export const SearchHistoryModalBody = ({
                       data-testid="search-history-content"
                       className={styles.conversationSnippet}
                       dangerouslySetInnerHTML={{
-                        __html: formatContentSnippet(conversation, searchTerm),
+                        __html: formatContentSnippet(conversation, inputValue),
                       }}
                     />
                   </div>

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -1,0 +1,100 @@
+import styles from './SearchHistoryModal.module.css';
+import { useRef } from 'react';
+import { useIsMobileLayout } from './theme/useIsMobileLayout';
+import ButtonIcon from './ButtonIcon';
+import { X } from 'lucide-react';
+import { ConversationHistory } from './types';
+
+interface SearchModalBodyProps {
+  conversations: ConversationHistory[];
+  onConversationSelect: (conversation: ConversationHistory) => void;
+  setIsOpen: (isOpen: boolean) => void;
+  searchTerm: string;
+  setSearchTerm: (searchTerm: string) => void;
+  onClose: () => void;
+}
+
+export const SearchHistoryModalBody = ({
+  // conversations,
+  // onConversationSelect,
+  setIsOpen,
+  searchTerm,
+  setSearchTerm,
+}: SearchModalBodyProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsOpen(false);
+      setSearchTerm('');
+    }
+  };
+
+  const isMobileLayout = useIsMobileLayout();
+  return (
+    <>
+      <div className={styles.searchInputWrapper}>
+        <input
+          ref={inputRef}
+          type="text"
+          className={styles.searchInput}
+          placeholder="Search conversations..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        {/*Mobile design uses the close icon within ModalWrapper*/}
+        {!isMobileLayout && (
+          <ButtonIcon
+            className={styles.searchCloseIcon}
+            icon={X}
+            aria-label="Close search modal"
+            // onClick={closeModalAndResetInput}
+          />
+        )}
+      </div>
+
+      {/*<div className={styles.results}>*/}
+      {/*  {Object.keys(groupedConversations).length === 0 ? (*/}
+      {/*    <div className={styles.noResults}>No results</div>*/}
+      {/*  ) : (*/}
+      {/*    Object.entries(groupedConversations).map(*/}
+      {/*      ([timeGroup, conversations]) => (*/}
+      {/*        <div key={timeGroup} className={styles.timeGroup}>*/}
+      {/*          <small className={styles.timeGroupTitle}>{timeGroup}</small>*/}
+      {/*          {conversations.map((conversation) => (*/}
+      {/*            <div*/}
+      {/*              data-testid="search-chat-history-entry"*/}
+      {/*              key={conversation.id}*/}
+      {/*              className={`${styles.conversationItem} ${conversationID === conversation.id ? styles.selected : ''}`}*/}
+      {/*              onClick={() => handleConversationClick(conversation)}*/}
+      {/*            >*/}
+      {/*              <p*/}
+      {/*                data-testid="search-history-title"*/}
+      {/*                className={styles.conversationTitle}*/}
+      {/*                dangerouslySetInnerHTML={{*/}
+      {/*                  __html: highlightMatch(*/}
+      {/*                    formatConversationTitle(conversation.title, 50),*/}
+      {/*                    searchTerm,*/}
+      {/*                  ),*/}
+      {/*                }}*/}
+      {/*              />*/}
+      {/*              <p*/}
+      {/*                data-testid="search-history-content"*/}
+      {/*                className={styles.conversationSnippet}*/}
+      {/*                dangerouslySetInnerHTML={{*/}
+      {/*                  __html: highlightMatch(*/}
+      {/*                    formatContentSnippet(conversation, searchTerm),*/}
+      {/*                    searchTerm,*/}
+      {/*                  ),*/}
+      {/*                }}*/}
+      {/*              />*/}
+      {/*            </div>*/}
+      {/*          ))}*/}
+      {/*        </div>*/}
+      {/*      ),*/}
+      {/*    )*/}
+      {/*  )}*/}
+      {/*</div>*/}
+    </>
+  );
+};

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -20,7 +20,7 @@ interface SearchModalBodyProps {
 
 export const SearchHistoryModalBody = ({
   searchableHistory,
-                                         onSelectConversation,
+  onSelectConversation,
   searchTerm,
   setSearchTerm,
   onClose,
@@ -36,6 +36,11 @@ export const SearchHistoryModalBody = ({
     searchableHistory,
     searchTerm,
   );
+
+  const onHistoryItemClick = (id: string) => {
+    onSelectConversation(id);
+    onClose();
+  };
 
   const isMobileLayout = useIsMobileLayout();
   return (
@@ -69,12 +74,12 @@ export const SearchHistoryModalBody = ({
             ([timeGroup, conversations]) => (
               <div key={timeGroup} className={styles.timeGroup}>
                 <small className={styles.timeGroupTitle}>{timeGroup}</small>
-                {conversations.map((conversation, index) => (
+                {conversations.map((conversation) => (
                   <div
                     data-testid="search-chat-history-entry"
-                    key={index}
+                    key={conversation.id}
                     className={styles.conversationItem}
-                    onClick={() => onSelectConversation(conversation.)}
+                    onClick={() => onHistoryItemClick(conversation.id)}
                   >
                     <p
                       data-testid="search-history-title"

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -58,14 +58,12 @@ export const SearchHistoryModalBody = ({
           autoFocus
         />
         {/*Mobile design uses the close icon within ModalWrapper*/}
-        {!isMobileLayout && (
-          <ButtonIcon
-            className={styles.searchCloseIcon}
-            icon={X}
-            aria-label="Close search modal"
-            onClick={onClose}
-          />
-        )}
+        <ButtonIcon
+          className={isMobileLayout ? styles.hidden : styles.searchCloseIcon}
+          icon={X}
+          aria-label="Close search modal"
+          onClick={onClose}
+        />
       </div>
 
       <div className={styles.results}>

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -3,10 +3,15 @@ import { useRef } from 'react';
 import { useIsMobileLayout } from './theme/useIsMobileLayout';
 import ButtonIcon from './ButtonIcon';
 import { X } from 'lucide-react';
-import { ConversationHistory } from './types';
+import { ConversationHistory, SearchableChatHistories } from './types';
+import {
+  formatContentSnippet,
+  formatConversationTitle,
+  groupAndFilterConversations,
+} from './utils/helpers';
 
 interface SearchModalBodyProps {
-  conversations: ConversationHistory[];
+  searchableHistory: SearchableChatHistories;
   onConversationSelect: (conversation: ConversationHistory) => void;
   setIsOpen: (isOpen: boolean) => void;
   searchTerm: string;
@@ -17,6 +22,7 @@ interface SearchModalBodyProps {
 export const SearchHistoryModalBody = ({
   // conversations,
   // onConversationSelect,
+  searchableHistory,
   setIsOpen,
   searchTerm,
   setSearchTerm,
@@ -28,6 +34,11 @@ export const SearchHistoryModalBody = ({
       setSearchTerm('');
     }
   };
+
+  const groupedConversations = groupAndFilterConversations(
+    searchableHistory,
+    searchTerm,
+  );
 
   const isMobileLayout = useIsMobileLayout();
   return (
@@ -53,48 +64,42 @@ export const SearchHistoryModalBody = ({
         )}
       </div>
 
-      {/*<div className={styles.results}>*/}
-      {/*  {Object.keys(groupedConversations).length === 0 ? (*/}
-      {/*    <div className={styles.noResults}>No results</div>*/}
-      {/*  ) : (*/}
-      {/*    Object.entries(groupedConversations).map(*/}
-      {/*      ([timeGroup, conversations]) => (*/}
-      {/*        <div key={timeGroup} className={styles.timeGroup}>*/}
-      {/*          <small className={styles.timeGroupTitle}>{timeGroup}</small>*/}
-      {/*          {conversations.map((conversation) => (*/}
-      {/*            <div*/}
-      {/*              data-testid="search-chat-history-entry"*/}
-      {/*              key={conversation.id}*/}
-      {/*              className={`${styles.conversationItem} ${conversationID === conversation.id ? styles.selected : ''}`}*/}
-      {/*              onClick={() => handleConversationClick(conversation)}*/}
-      {/*            >*/}
-      {/*              <p*/}
-      {/*                data-testid="search-history-title"*/}
-      {/*                className={styles.conversationTitle}*/}
-      {/*                dangerouslySetInnerHTML={{*/}
-      {/*                  __html: highlightMatch(*/}
-      {/*                    formatConversationTitle(conversation.title, 50),*/}
-      {/*                    searchTerm,*/}
-      {/*                  ),*/}
-      {/*                }}*/}
-      {/*              />*/}
-      {/*              <p*/}
-      {/*                data-testid="search-history-content"*/}
-      {/*                className={styles.conversationSnippet}*/}
-      {/*                dangerouslySetInnerHTML={{*/}
-      {/*                  __html: highlightMatch(*/}
-      {/*                    formatContentSnippet(conversation, searchTerm),*/}
-      {/*                    searchTerm,*/}
-      {/*                  ),*/}
-      {/*                }}*/}
-      {/*              />*/}
-      {/*            </div>*/}
-      {/*          ))}*/}
-      {/*        </div>*/}
-      {/*      ),*/}
-      {/*    )*/}
-      {/*  )}*/}
-      {/*</div>*/}
+      <div className={styles.results}>
+        {Object.keys(groupedConversations).length === 0 ? (
+          <div className={styles.noResults}>No results</div>
+        ) : (
+          Object.entries(groupedConversations).map(
+            ([timeGroup, conversations]) => (
+              <div key={timeGroup} className={styles.timeGroup}>
+                <small className={styles.timeGroupTitle}>{timeGroup}</small>
+                {conversations.map((conversation) => (
+                  <div
+                    data-testid="search-chat-history-entry"
+                    // key={conversation.id}
+                    // className={`${styles.conversationItem} ${conversationID === conversation.id ? styles.selected : ''}`}
+                    // onClick={() => handleConversationClick(conversation)}
+                  >
+                    <p
+                      data-testid="search-history-title"
+                      className={styles.conversationTitle}
+                      dangerouslySetInnerHTML={{
+                        __html: formatConversationTitle(conversation.title, 50),
+                      }}
+                    />
+                    <p
+                      data-testid="search-history-content"
+                      className={styles.conversationSnippet}
+                      dangerouslySetInnerHTML={{
+                        __html: formatContentSnippet(conversation, searchTerm),
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+            ),
+          )
+        )}
+      </div>
     </>
   );
 };

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { useIsMobileLayout } from './theme/useIsMobileLayout';
 import ButtonIcon from './ButtonIcon';
 import { X } from 'lucide-react';
-import { ConversationHistory, SearchableChatHistories } from './types';
+import { SearchableChatHistories } from './types';
 import {
   formatContentSnippet,
   formatConversationTitle,
@@ -12,26 +12,23 @@ import {
 
 interface SearchModalBodyProps {
   searchableHistory: SearchableChatHistories;
-  onConversationSelect: (conversation: ConversationHistory) => void;
-  setIsOpen: (isOpen: boolean) => void;
+  onSelectConversation: (id: string) => void;
   searchTerm: string;
   setSearchTerm: (searchTerm: string) => void;
   onClose: () => void;
 }
 
 export const SearchHistoryModalBody = ({
-  // conversations,
-  // onConversationSelect,
   searchableHistory,
-  setIsOpen,
+                                         onSelectConversation,
   searchTerm,
   setSearchTerm,
+  onClose,
 }: SearchModalBodyProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
-      setIsOpen(false);
-      setSearchTerm('');
+      onClose();
     }
   };
 
@@ -59,7 +56,7 @@ export const SearchHistoryModalBody = ({
             className={styles.searchCloseIcon}
             icon={X}
             aria-label="Close search modal"
-            // onClick={closeModalAndResetInput}
+            onClick={onClose}
           />
         )}
       </div>
@@ -72,12 +69,12 @@ export const SearchHistoryModalBody = ({
             ([timeGroup, conversations]) => (
               <div key={timeGroup} className={styles.timeGroup}>
                 <small className={styles.timeGroupTitle}>{timeGroup}</small>
-                {conversations.map((conversation) => (
+                {conversations.map((conversation, index) => (
                   <div
                     data-testid="search-chat-history-entry"
-                    // key={conversation.id}
-                    // className={`${styles.conversationItem} ${conversationID === conversation.id ? styles.selected : ''}`}
-                    // onClick={() => handleConversationClick(conversation)}
+                    key={index}
+                    className={styles.conversationItem}
+                    onClick={() => onSelectConversation(conversation.)}
                   >
                     <p
                       data-testid="search-history-title"

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -68,20 +68,17 @@ export const SearchHistoryModalBody = ({
                 <small className={styles.timeGroupTitle}>{timeGroup}</small>
                 {conversations.map((conversation) => (
                   <div
-                    data-testid="search-chat-history-entry"
                     key={conversation.id}
                     className={styles.conversationItem}
                     onClick={() => onHistoryItemClick(conversation.id)}
                   >
                     <p
-                      data-testid="search-history-title"
                       className={styles.conversationTitle}
                       dangerouslySetInnerHTML={{
                         __html: formatConversationTitle(conversation.title, 50),
                       }}
                     />
                     <p
-                      data-testid="search-history-content"
                       className={styles.conversationSnippet}
                       dangerouslySetInnerHTML={{
                         __html: formatContentSnippet(conversation, inputValue),

--- a/src/SearchHistoryModalBody.tsx
+++ b/src/SearchHistoryModalBody.tsx
@@ -22,12 +22,22 @@ export const SearchHistoryModalBody = ({
   onClose,
 }: SearchModalBodyProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       onClose();
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      //  if there's only one remaining search match, allow it to be selected with the enter key
+      const allConversations = Object.values(groupedConversations).flat();
+      if (allConversations.length === 1) {
+        onSelectConversation(allConversations[0].id);
+        onClose();
+      }
     }
   };
-
   const onHistoryItemClick = (id: string) => {
     onSelectConversation(id);
     onClose();

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -93,7 +93,6 @@ export const SideBar = ({
           onSelectConversation={onSelectConversation}
           isSearchHistoryOpen={isSearchHistoryOpen}
           onCloseSearchHistory={onCloseSearchHistory}
-          setIsMobileSideBarOpen={onMobileCloseClick}
         />
       )}
     </div>

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -46,6 +46,10 @@ export const SideBar = ({
     }
   };
 
+  const onCloseSearchHistory = () => {
+    setIsSearchHistoryOpen(false);
+  };
+
   const isMobileLayout = useIsMobileLayout();
   const showMobileSideBar = isMobileLayout && isMobileSideBarOpen;
   const showDesktopSideBar = !isMobileLayout && isDesktopSideBarOpen;
@@ -86,8 +90,9 @@ export const SideBar = ({
       {isSearchHistoryOpen && searchableHistory && (
         <SearchHistoryModal
           searchableHistory={searchableHistory}
+          onSelectConversation={onSelectConversation}
           isSearchHistoryOpen={isSearchHistoryOpen}
-          setIsSearchHistoryOpen={setIsSearchHistoryOpen}
+          onCloseSearchHistory={onCloseSearchHistory}
           setIsMobileSideBarOpen={onMobileCloseClick}
         />
       )}

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -85,6 +85,7 @@ export const SideBar = ({
 
       {isSearchHistoryOpen && searchableHistory && (
         <SearchHistoryModal
+          searchableHistory={searchableHistory}
           isSearchHistoryOpen={isSearchHistoryOpen}
           setIsSearchHistoryOpen={setIsSearchHistoryOpen}
           setIsMobileSideBarOpen={onMobileCloseClick}

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -91,7 +91,6 @@ export const SideBar = ({
         <SearchHistoryModal
           searchableHistory={searchableHistory}
           onSelectConversation={onSelectConversation}
-          isSearchHistoryOpen={isSearchHistoryOpen}
           onCloseSearchHistory={onCloseSearchHistory}
         />
       )}

--- a/src/SideBar.tsx
+++ b/src/SideBar.tsx
@@ -7,6 +7,7 @@ import { useIsMobileLayout } from './theme/useIsMobileLayout';
 import { ConversationHistories, SearchableChatHistories } from './types';
 import { useState } from 'react';
 import { getSearchableHistory } from './api/getSearchableHistory';
+import { SearchHistoryModal } from './SearchHistoryModal';
 
 export interface SideBarProps {
   conversationHistories: ConversationHistories;
@@ -82,8 +83,13 @@ export const SideBar = ({
         />
       </div>
 
-      {/*todo - implement modal*/}
-      {isSearchHistoryOpen && searchableHistory && <></>}
+      {isSearchHistoryOpen && searchableHistory && (
+        <SearchHistoryModal
+          isSearchHistoryOpen={isSearchHistoryOpen}
+          setIsSearchHistoryOpen={setIsSearchHistoryOpen}
+          setIsMobileSideBarOpen={onMobileCloseClick}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- click the icon to open the modal
- input filters by search term
- clicking an entry makes it the active chat
- if only one entry remains, it can be selected by the enter key 
- modal closes on outside click or escape key press

https://github.com/user-attachments/assets/79e58421-b53e-4055-ab70-34f0723fe63e

