### PR TITLE
refactor: lift state for editing histories into parent

### DIFF
--- a/src/ChatHistory.test.tsx
+++ b/src/ChatHistory.test.tsx
@@ -111,6 +111,7 @@ describe('ChatHistory Component', () => {
 
     expect(mockProps.onDeleteConversation).toHaveBeenCalledWith('conv-today-1');
   });
+
   it('clicking rename button opens an editable input', async () => {
     render(
       <ChatHistory
@@ -149,5 +150,176 @@ describe('ChatHistory Component', () => {
     fireEvent.click(screen.getByLabelText('Chat Options'));
 
     expect(editInput).not.toBeInTheDocument();
+  });
+
+  it('should update input value as user types', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: 'Updated Title' } });
+
+    expect(input).toHaveValue('Updated Title');
+  });
+
+  it('should save title when Enter key is pressed', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: 'Updated Title' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockProps.onUpdateConversationTitle).toHaveBeenCalledWith(
+      'conv-today-1',
+      'Updated Title',
+    );
+  });
+
+  it('should save title when clicking outside while in edit mode', () => {
+    render(
+      <div>
+        <div data-testid="outside-element">Outside Element</div>
+        <ChatHistory
+          chatHistories={mockHistories}
+          activeConversationId={'123'}
+          {...mockProps}
+        />
+      </div>,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, {
+      target: { value: 'New Title from Outside Click' },
+    });
+
+    fireEvent.mouseDown(screen.getByTestId('outside-element'));
+
+    expect(mockProps.onUpdateConversationTitle).toHaveBeenCalledWith(
+      'conv-today-1',
+      'New Title from Outside Click',
+    );
+  });
+
+  it('should not save empty title but revert to original', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockProps.onUpdateConversationTitle).not.toHaveBeenCalled();
+    expect(screen.getByText('First Today Conversation')).toBeInTheDocument();
+  });
+
+  it('should cancel editing when Escape key is pressed', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: 'Updated Title' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(mockProps.onUpdateConversationTitle).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('Edit Title Input')).not.toBeInTheDocument();
+    expect(screen.getByText('First Today Conversation')).toBeInTheDocument();
+  });
+
+  it('should delete conversation when delete button is clicked', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete Chat' });
+    fireEvent.click(deleteButton);
+
+    expect(mockProps.onDeleteConversation).toHaveBeenCalledWith('conv-today-1');
+  });
+
+  it('should not update title if the trimmed value is the same as the original', () => {
+    render(
+      <ChatHistory
+        chatHistories={mockHistories}
+        activeConversationId={'123'}
+        {...mockProps}
+      />,
+    );
+
+    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
+    fireEvent.click(menuButton);
+
+    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText('Edit Title Input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, {
+      target: { value: '   First Today Conversation    ' },
+    });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockProps.onUpdateConversationTitle).not.toHaveBeenCalled();
   });
 });

--- a/src/ChatHistory.tsx
+++ b/src/ChatHistory.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { ChatHistoryItem } from './ChatHistoryItem';
 import styles from './ChatHistory.module.css';
 import { ConversationHistories } from './types';
@@ -26,6 +26,17 @@ export const ChatHistory = memo(
       [chatHistories],
     );
 
+    const [isEditMenuOpen, setIsEditMenuOpen] = useState(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+
+    const toggleEditingTitle = (isEditing: boolean) => {
+      setIsEditingTitle(isEditing);
+    };
+
+    const handleMenuOpen = (open: boolean) => {
+      setIsEditMenuOpen(open);
+    };
+
     return (
       <div className={styles.chatHistoryContainer}>
         {Object.values(chatHistories).length === 0 ? (
@@ -51,6 +62,10 @@ export const ChatHistory = memo(
                       deleteConversation={onDeleteConversation}
                       updateConversationTitle={onUpdateConversationTitle}
                       isSelected={activeConversationId === conversation.id}
+                      isMenuOpen={isEditMenuOpen}
+                      isEditingTitle={isEditingTitle}
+                      handleMenuOpen={handleMenuOpen}
+                      toggleEditingTitle={toggleEditingTitle}
                     />
                   ))}
                 </div>

--- a/src/ChatHistoryItem.test.tsx
+++ b/src/ChatHistoryItem.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ChatHistoryItem } from './ChatHistoryItem';
+import { ChatHistoryItem, ChatHistoryItemProps } from './ChatHistoryItem';
 import { ConversationHistory } from './types';
 
 describe('ChatHistoryItem Component', () => {
@@ -12,12 +12,16 @@ describe('ChatHistoryItem Component', () => {
     tokensRemaining: 6453,
   };
 
-  const mockProps = {
+  const mockProps: ChatHistoryItemProps = {
     conversation: mockConversation,
     onHistoryItemClick: vi.fn(),
     deleteConversation: vi.fn(),
     updateConversationTitle: vi.fn(),
     isSelected: false,
+    isMenuOpen: false,
+    isEditingTitle: false,
+    toggleEditingTitle: vi.fn(),
+    handleMenuOpen: vi.fn(),
   };
 
   beforeEach(() => {
@@ -56,174 +60,5 @@ describe('ChatHistoryItem Component', () => {
 
     expect(screen.getByRole('button', { name: 'Rename Title' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Delete Chat' })).toBeVisible();
-  });
-
-  it('should enter edit mode when rename button is clicked', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    expect(input).toBeVisible();
-    expect(input).toHaveValue('Test Conversation');
-  });
-
-  it('should update input value as user types', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.change(input, { target: { value: 'Updated Title' } });
-
-    expect(input).toHaveValue('Updated Title');
-  });
-
-  it('should save title when Enter key is pressed', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.change(input, { target: { value: 'Updated Title' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(mockProps.updateConversationTitle).toHaveBeenCalledWith(
-      'conv-2025-03-19-001',
-      'Updated Title',
-    );
-  });
-
-  it('should not save empty title but revert to original', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(mockProps.updateConversationTitle).not.toHaveBeenCalled();
-    expect(screen.getByText('Test Conversation')).toBeInTheDocument();
-  });
-
-  it('should cancel editing when Escape key is pressed', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.change(input, { target: { value: 'Updated Title' } });
-    fireEvent.keyDown(input, { key: 'Escape' });
-
-    expect(mockProps.updateConversationTitle).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText('Edit Title Input')).not.toBeInTheDocument();
-    expect(screen.getByText('Test Conversation')).toBeInTheDocument();
-  });
-
-  it('should delete conversation when delete button is clicked', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const deleteButton = screen.getByRole('button', { name: 'Delete Chat' });
-    fireEvent.click(deleteButton);
-
-    expect(mockProps.deleteConversation).toHaveBeenCalledWith(
-      'conv-2025-03-19-001',
-    );
-  });
-
-  it('should not update title if the trimmed value is the same as the original', () => {
-    render(<ChatHistoryItem {...mockProps} />);
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.change(input, { target: { value: '  Test Conversation  ' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(mockProps.updateConversationTitle).not.toHaveBeenCalled();
-  });
-
-  it('should save title when clicking outside while in edit mode', () => {
-    render(
-      <div>
-        <div data-testid="outside-element">Outside Element</div>
-        <ChatHistoryItem {...mockProps} />
-      </div>,
-    );
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.change(input, {
-      target: { value: 'New Title from Outside Click' },
-    });
-
-    fireEvent.mouseDown(screen.getByTestId('outside-element'));
-
-    expect(mockProps.updateConversationTitle).toHaveBeenCalledWith(
-      'conv-2025-03-19-001',
-      'New Title from Outside Click',
-    );
-  });
-  it('should handle data-menu-button elements correctly in click outside handler', () => {
-    render(
-      <div>
-        <button data-testid="menu-button-element" data-menu-button="true">
-          Menu Button
-        </button>
-        <ChatHistoryItem {...mockProps} />
-      </div>,
-    );
-
-    const menuButton = screen.getByRole('button', { name: 'Chat Options' });
-    fireEvent.click(menuButton);
-
-    const renameButton = screen.getByRole('button', { name: 'Rename Title' });
-    fireEvent.click(renameButton);
-
-    const input = screen.getByLabelText('Edit Title Input');
-    fireEvent.change(input, { target: { value: '' } });
-
-    fireEvent.click(screen.getByTestId('menu-button-element'));
-
-    expect(input).toBeInTheDocument();
-    expect(mockProps.updateConversationTitle).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Moves state for opening edit menu out of chat history item to its parent.

The only local state that remains in the history item is input value if the user is changing the title.