### PR TITLE
refactor: icon only progress state (use existing data)

### DIFF
--- a/src/Conversation.module.css
+++ b/src/Conversation.module.css
@@ -88,14 +88,59 @@ li {
   left: 0;
 }
 
-@keyframes pulse {
+.brainIconContainer {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-xs);
+  border-radius: 50%;
+  background: var(--colors-accentTwoBorder);
+  transition: background 0.3s ease;
+  width: fit-content;
+  margin-right: 2rem;
+  height: fit-content;
+}
+
+.brainIcon {
+  color: var(--colors-accentTwo);
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+  display: block;
+}
+
+.brainIconContainer.pulsing {
+  animation: iconContainerPulse 2s ease-in-out infinite;
+  box-shadow: 0 0 8px 2px var(--colors-accentTwo);
+}
+
+.brainIcon.pulsing {
+  animation: iconPulse 2s ease-in-out infinite;
+  position: relative;
+  z-index: 2;
+}
+
+@keyframes iconContainerPulse {
   0% {
-    opacity: 0.6;
+    background: rgba(var(--colors-accentTwo), 0.2);
+    box-shadow: 0 0 5px 1px var(--colors-accentTwo);
   }
   50% {
-    opacity: 0.8;
+    background: rgba(var(--colors-accentTwo), 0.6);
+    box-shadow: 0 0 12px 3px var(--colors-accentTwo);
   }
   100% {
-    opacity: 0.6;
+    background: rgba(var(--colors-accentTwo), 0.2);
+    box-shadow: 0 0 5px 1px var(--colors-accentTwo);
+  }
+}
+
+@keyframes iconPulse {
+  0% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.7;
   }
 }

--- a/src/Conversation.test.tsx
+++ b/src/Conversation.test.tsx
@@ -17,7 +17,6 @@ describe('Conversation Component', () => {
       <Conversation
         isRequesting={false}
         messages={[]}
-        progressText=""
         errorText=""
         assistantStream=""
         onRendered={vi.fn()}
@@ -40,7 +39,6 @@ describe('Conversation Component', () => {
       <Conversation
         isRequesting={false}
         messages={messages}
-        progressText=""
         errorText=""
         assistantStream=""
         onRendered={vi.fn()}
@@ -68,7 +66,6 @@ describe('Conversation Component', () => {
       <Conversation
         isRequesting={false}
         messages={messages}
-        progressText=""
         errorText=""
         assistantStream=""
         onRendered={vi.fn()}

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -88,13 +88,13 @@ const ConversationComponent = ({
                   className={`${styles.brainIcon} ${styles.pulsing}`}
                   aria-label="Progress Icon"
                 />
-                <Content
-                  content={assistantStream}
-                  role="assistant"
-                  onRendered={onRendered}
-                />
               </div>
             )}
+            <Content
+              content={assistantStream}
+              role="assistant"
+              onRendered={onRendered}
+            />
           </div>
         </div>
       )}

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -82,19 +82,20 @@ const ConversationComponent = ({
       {isRequesting && (
         <div className={styles.assistantOutputContainer}>
           <div className={styles.assistantContainer}>
-            {assistantStream.length === 0 && (
+            {assistantStream.length === 0 ? (
               <div className={`${styles.brainIconContainer} ${styles.pulsing}`}>
                 <BrainIcon
                   className={`${styles.brainIcon} ${styles.pulsing}`}
                   aria-label="Progress Icon"
                 />
               </div>
+            ) : (
+              <Content
+                content={assistantStream}
+                role="assistant"
+                onRendered={onRendered}
+              />
             )}
-            <Content
-              content={assistantStream}
-              role="assistant"
-              onRendered={onRendered}
-            />
           </div>
         </div>
       )}

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -12,6 +12,7 @@ import { TextStreamStore } from './stores/textStreamStore';
 import { ToolCallStreamStore } from './stores/toolCallStreamStore';
 import { ToolCallRegistry } from './toolcalls/chain';
 import { ToolMessageContainer } from './toolcalls/components/ToolCallMessageContainer';
+import { BrainIcon } from 'lucide-react';
 
 export type ChatMessage =
   | ChatCompletionMessageParam
@@ -20,7 +21,6 @@ export type ChatMessage =
 
 export interface ConversationProps {
   messages: ChatMessage[];
-  progressText: string;
   assistantStream: string;
   errorText: string;
   isRequesting: boolean;
@@ -34,11 +34,9 @@ export interface ConversationProps {
 const ConversationComponent = ({
   messages,
   isRequesting,
-  progressText,
   errorText,
   assistantStream,
   onRendered,
-
   progressStore,
   toolCallStreamStore,
   toolCallRegistry,
@@ -84,20 +82,19 @@ const ConversationComponent = ({
       {isRequesting && (
         <div className={styles.assistantOutputContainer}>
           <div className={styles.assistantContainer}>
-            {progressText.length ? (
-              <div className={styles.progressStream}>
+            {assistantStream.length === 0 && (
+              <div className={`${styles.brainIconContainer} ${styles.pulsing}`}>
+                <BrainIcon
+                  className={`${styles.brainIcon} ${styles.pulsing}`}
+                  aria-label="Progress Icon"
+                />
                 <Content
-                  content={progressText}
+                  content={assistantStream}
                   role="assistant"
                   onRendered={onRendered}
                 />
               </div>
-            ) : null}
-            <Content
-              content={assistantStream}
-              role="assistant"
-              onRendered={onRendered}
-            />
+            )}
           </div>
         </div>
       )}

--- a/src/ConversationWrapper.tsx
+++ b/src/ConversationWrapper.tsx
@@ -17,7 +17,6 @@ export const ConversationWrapper = ({
 }: ConversationWrapperProps) => {
   const messages = useMessageHistoryStore(activeChat.messageHistoryStore);
   const assistantStream = useTextStreamStore(activeChat.messageStore);
-  const progressText = useTextStreamStore(activeChat.progressStore);
   const errorText = useTextStreamStore(activeChat.errorStore);
   const isRequesting = activeChat.isRequesting;
 
@@ -25,7 +24,6 @@ export const ConversationWrapper = ({
     <Conversation
       messages={messages}
       assistantStream={assistantStream}
-      progressText={progressText}
       errorText={errorText}
       isRequesting={isRequesting}
       isOperationValidated={activeChat.isOperationValidated}


### PR DESCRIPTION
Since we have access to the `assistantStream` in the component, we can show the icon once `isRequesting` is true, but before the assistant stream has any content

https://github.com/user-attachments/assets/95b2cff2-f4a8-4e3e-9d2f-dce993e04da2


