### PR TITLE
refactor: pass array of tool call streams instead of store

### DIFF
--- a/src/Conversation.test.tsx
+++ b/src/Conversation.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Conversation, ChatMessage } from './Conversation';
-import { ToolCallStreamStore } from './stores/toolCallStreamStore';
 import { initializeToolCallRegistry } from './toolcalls/chain';
 
 vi.mock('./Content', () => ({
@@ -20,7 +19,7 @@ describe('Conversation Component', () => {
         assistantStream=""
         onRendered={vi.fn()}
         isOperationValidated={false}
-        toolCallStreamStore={new ToolCallStreamStore()}
+        toolCallStreams={[]}
         toolCallRegistry={initializeToolCallRegistry()}
       />,
     );
@@ -41,7 +40,7 @@ describe('Conversation Component', () => {
         assistantStream=""
         onRendered={vi.fn()}
         isOperationValidated={false}
-        toolCallStreamStore={new ToolCallStreamStore()}
+        toolCallStreams={[]}
         toolCallRegistry={initializeToolCallRegistry()}
       />,
     );
@@ -67,7 +66,7 @@ describe('Conversation Component', () => {
         assistantStream=""
         onRendered={vi.fn()}
         isOperationValidated={false}
-        toolCallStreamStore={new ToolCallStreamStore()}
+        toolCallStreams={[]}
         toolCallRegistry={initializeToolCallRegistry()}
       />,
     );

--- a/src/Conversation.tsx
+++ b/src/Conversation.tsx
@@ -8,7 +8,7 @@ import {
 import AssistantMessage from './AssistantMessage';
 import { Content } from './Content';
 import { ToolCallProgressCards } from './ToolCallProgressCards';
-import { ToolCallStreamStore } from './stores/toolCallStreamStore';
+import { ToolCallStream } from './stores/toolCallStreamStore';
 import { ToolCallRegistry } from './toolcalls/chain';
 import { ToolMessageContainer } from './toolcalls/components/ToolCallMessageContainer';
 import { BrainIcon } from 'lucide-react';
@@ -24,7 +24,7 @@ export interface ConversationProps {
   errorText: string;
   isRequesting: boolean;
   onRendered: () => void;
-  toolCallStreamStore: ToolCallStreamStore;
+  toolCallStreams: Array<ToolCallStream>;
   toolCallRegistry: ToolCallRegistry<unknown>;
   isOperationValidated: boolean;
 }
@@ -35,7 +35,7 @@ const ConversationComponent = ({
   errorText,
   assistantStream,
   onRendered,
-  toolCallStreamStore,
+  toolCallStreams,
   toolCallRegistry,
   isOperationValidated,
 }: ConversationProps) => {
@@ -112,7 +112,7 @@ const ConversationComponent = ({
       <ToolCallProgressCards
         isOperationValidated={isOperationValidated}
         onRendered={onRendered}
-        toolCallStreamStore={toolCallStreamStore}
+        toolCallStreams={toolCallStreams}
         toolCallRegistry={toolCallRegistry}
       />
     </div>

--- a/src/ConversationWrapper.tsx
+++ b/src/ConversationWrapper.tsx
@@ -3,6 +3,7 @@ import { useMessageHistoryStore } from './stores/messageHistoryStore';
 import { useTextStreamStore } from './stores/textStreamStore';
 import { ActiveChat } from './types';
 import { ToolCallRegistry } from './toolcalls/chain';
+import { useToolCallStreamStore } from './stores/toolCallStreamStore';
 
 interface ConversationWrapperProps {
   activeChat: ActiveChat;
@@ -15,10 +16,19 @@ export const ConversationWrapper = ({
   onRendered,
   toolCallRegistry,
 }: ConversationWrapperProps) => {
-  const messages = useMessageHistoryStore(activeChat.messageHistoryStore);
-  const assistantStream = useTextStreamStore(activeChat.messageStore);
-  const errorText = useTextStreamStore(activeChat.errorStore);
-  const isRequesting = activeChat.isRequesting;
+  const {
+    messageHistoryStore,
+    messageStore,
+    toolCallStreamStore,
+    errorStore,
+    isRequesting,
+    isOperationValidated,
+  } = activeChat;
+
+  const messages = useMessageHistoryStore(messageHistoryStore);
+  const assistantStream = useTextStreamStore(messageStore);
+  const toolCallStreams = useToolCallStreamStore(toolCallStreamStore);
+  const errorText = useTextStreamStore(errorStore);
 
   return (
     <Conversation
@@ -26,9 +36,9 @@ export const ConversationWrapper = ({
       assistantStream={assistantStream}
       errorText={errorText}
       isRequesting={isRequesting}
-      isOperationValidated={activeChat.isOperationValidated}
+      isOperationValidated={isOperationValidated}
       onRendered={onRendered}
-      toolCallStreamStore={activeChat.toolCallStreamStore}
+      toolCallStreams={toolCallStreams}
       toolCallRegistry={toolCallRegistry}
     />
   );

--- a/src/ToolCallProgressCards.tsx
+++ b/src/ToolCallProgressCards.tsx
@@ -1,23 +1,17 @@
-import { useSyncExternalStore } from 'react';
-import { ToolCallStreamStore } from './stores/toolCallStreamStore';
+import { ToolCallStream } from './stores/toolCallStreamStore';
 import { ToolCallRegistry } from './toolcalls/chain';
 
 export const ToolCallProgressCards = ({
   onRendered,
-  toolCallStreamStore,
+  toolCallStreams,
   toolCallRegistry,
   isOperationValidated,
 }: {
   onRendered: () => void;
-  toolCallStreamStore: ToolCallStreamStore;
+  toolCallStreams: Array<ToolCallStream>;
   toolCallRegistry: ToolCallRegistry<unknown>;
   isOperationValidated: boolean;
 }) => {
-  const toolCallStreams = useSyncExternalStore(
-    toolCallStreamStore.subscribe,
-    toolCallStreamStore.getSnapShot,
-  );
-
   if (!toolCallStreams.length) return null;
 
   return toolCallStreams.map((toolCall) => {


### PR DESCRIPTION
Following the pattern in `ConversationWrapper` subscribe to the tool call stream store and then pass down the array of streams to the children.

