### PR TITLE
fix: initiate conversation histories as null instead of empty object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6746,7 +6746,7 @@
     },
     "node_modules/lib-kava-ai": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Kava-Labs/lib-kava-ai.git#1bf749007cdcb16d8e34a6b12b4c09886a5407f4",
+      "resolved": "git+ssh://git@github.com/Kava-Labs/lib-kava-ai.git#1da0fb85e665a3dda2ec88266bd72fcfda6fb860",
       "hasInstallScript": true,
       "peerDependencies": {
         "dompurify": "^3.2.4",

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -38,7 +38,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
   });
 
   const [conversationHistories, setConversationHistories] =
-    useState<ConversationHistories>({});
+    useState<ConversationHistories | null>(null);
 
   // **********
   const [activeChat, setActiveChat] = useState<ActiveChat>({
@@ -119,7 +119,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       // todo: sync local storage before response
       let conversation: ConversationHistory;
 
-      if (conversationHistories[activeChat.id]) {
+      if (conversationHistories && conversationHistories[activeChat.id]) {
         conversation = conversationHistories[activeChat.id];
         conversation.lastSaved = Date.now();
       } else {
@@ -199,7 +199,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
   const onSelectConversation = useCallback(
     async (id: string) => {
       // already selected
-      if (id === activeChat.id) return;
+      if (id === activeChat.id || !conversationHistories) return;
 
       if (activeChats[id]) {
         setActiveChat(activeChats[id]);


### PR DESCRIPTION
## What Changes
Similar to https://github.com/Kava-Labs/oros/commit/a66bd4ef6d14eea7dfadf3a562a5e157c3c54087, sets the initial value of conversation histories as null instead of an empty object. It will be easier to distinguish in the UI if the user has no history or if the page isn't fully loaded yet.

## Before
Empty history placeholder flashes

https://github.com/user-attachments/assets/60087efa-3fe9-4a4d-b0ad-84428fa09f34

## After
Component doesn't render until its data its loaded

https://github.com/user-attachments/assets/4e1dabbb-7983-4de0-8634-66db60eba010


