### PR TITLE
feat: integrate wallet connection modal with tool calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,6 @@ export const App = () => {
     toolCallRegistry,
     walletAddress,
     disconnectWallet,
-    detectProviders,
     handleProviderSelect,
     availableProviders,
     walletProviderInfo,
@@ -61,8 +60,7 @@ export const App = () => {
     isWalletConnectOpen,
   } = useChat();
 
-  const openWalletConnect = async () => {
-    await detectProviders();
+  const openWalletConnect = () => {
     openWalletConnectModal();
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ export const App = () => {
   const [isMobileSideBarOpen, setIsMobileSideBarOpen] = useState(false);
   const [isDesktopSideBarOpen, setIsDesktopSideBarOpen] = useState(true);
   const [isSearchHistoryOpen, setIsSearchHistoryOpen] = useState(false);
-  const [isWalletConnectOpen, setIsWalletConnectOpen] = useState(false);
 
   const onCloseSearchHistory = () => {
     setIsSearchHistoryOpen(false);
@@ -57,20 +56,23 @@ export const App = () => {
     handleProviderSelect,
     availableProviders,
     walletProviderInfo,
+    openWalletConnectModal,
+    closeWalletConnectModal,
+    isWalletConnectOpen,
   } = useChat();
 
   const openWalletConnect = async () => {
     await detectProviders();
-    setIsWalletConnectOpen(true);
+    openWalletConnectModal();
   };
 
   const closeWalletConnect = () => {
-    setIsWalletConnectOpen(false);
+    closeWalletConnectModal();
   };
 
   const onProviderSelect = async (provider: WalletProviderDetail) => {
     await handleProviderSelect(provider);
-    closeWalletConnect();
+    closeWalletConnectModal();
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ export const App = () => {
     walletProviderInfo,
     openWalletConnectModal,
     closeWalletConnectModal,
-    isWalletConnectOpen,
+    isWalletModalOpen,
   } = useChat();
 
   const openWalletConnect = () => {
@@ -110,7 +110,7 @@ export const App = () => {
         />
       )}
 
-      {isWalletConnectOpen && (
+      {isWalletModalOpen && (
         <WalletModal
           onClose={closeWalletConnect}
           availableProviders={availableProviders}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { useIsMobileLayout, SearchHistoryModal, SideBar } from 'lib-kava-ai';
 import hardAILogo from './assets/hardAILogo.svg';
 import WalletModal from './WalletModal';
 import { PROMOTED_WALLETS } from './utils/wallet';
-import { WalletProviderDetail } from './types';
 
 const sideBarLogo = <img src={hardAILogo} alt="Hard AI logo" height={18} />;
 
@@ -52,26 +51,13 @@ export const App = () => {
     toolCallRegistry,
     walletAddress,
     disconnectWallet,
-    handleProviderSelect,
     availableProviders,
     walletProviderInfo,
     openWalletConnectModal,
     closeWalletConnectModal,
     isWalletModalOpen,
+    onProviderSelect,
   } = useChat();
-
-  const openWalletConnect = () => {
-    openWalletConnectModal();
-  };
-
-  const closeWalletConnect = () => {
-    closeWalletConnectModal();
-  };
-
-  const onProviderSelect = async (provider: WalletProviderDetail) => {
-    await handleProviderSelect(provider);
-    closeWalletConnectModal();
-  };
 
   return (
     <div className={styles.app}>
@@ -98,7 +84,7 @@ export const App = () => {
         styles={styles}
         walletAddress={walletAddress}
         walletProviderInfo={walletProviderInfo}
-        onConnectWalletClick={openWalletConnect}
+        onConnectWalletClick={openWalletConnectModal}
         disconnectWallet={disconnectWallet}
         availableProviderCount={availableProviders.length}
       />
@@ -112,7 +98,7 @@ export const App = () => {
 
       {isWalletModalOpen && (
         <WalletModal
-          onClose={closeWalletConnect}
+          onClose={closeWalletConnectModal}
           availableProviders={availableProviders}
           onSelectProvider={onProviderSelect}
           promotedWallets={PROMOTED_WALLETS}

--- a/src/WalletModal.tsx
+++ b/src/WalletModal.tsx
@@ -53,7 +53,7 @@ const WalletModal: React.FC<WalletModalProps> = ({
           <h3>{hasProviders ? 'Select a Wallet' : 'Get a Wallet'}</h3>
           <ButtonIcon
             icon={X}
-            aria-label={'Close wallet connect'}
+            aria-label={'Close wallet modal'}
             onClick={onClose}
           />
         </div>

--- a/src/WalletModal.tsx
+++ b/src/WalletModal.tsx
@@ -53,7 +53,7 @@ const WalletModal: React.FC<WalletModalProps> = ({
           <h3>{hasProviders ? 'Select a Wallet' : 'Get a Wallet'}</h3>
           <ButtonIcon
             icon={X}
-            aria-label={'Close wallet modal'}
+            aria-label={'Close wallet connect'}
             onClick={onClose}
           />
         </div>

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -46,6 +46,13 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
   const [conversationHistories, setConversationHistories] =
     useState<ConversationHistories | null>(null);
 
+  const [isWalletConnectOpen, setIsWalletConnectOpen] = useState(false);
+
+  const openWalletConnectModal = () => {
+    refreshProviders();
+    setIsWalletConnectOpen(true);
+  };
+
   // **********
   const [activeChat, setActiveChat] = useState<ActiveChat>({
     id: uuidv4(), // add uuid v4 for conversation id
@@ -126,12 +133,20 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     [],
   );
 
-  const { executeOperation } = useExecuteToolCall(
+  const { executeOperation, handleModalClose } = useExecuteToolCall(
     toolCallRegistry,
     walletStore,
     activeChat.isOperationValidated,
     setIsOperationValidated,
+    openWalletConnectModal,
   );
+
+  const closeWalletConnectModal = useCallback(() => {
+    setIsWalletConnectOpen(false);
+    if (handleModalClose) {
+      handleModalClose();
+    }
+  }, [handleModalClose]);
 
   const fetchConversations = useCallback(() => {
     getAllConversations()
@@ -349,9 +364,13 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       disconnectWallet,
       availableProviders,
       walletProviderInfo,
+      isWalletConnectOpen,
+      openWalletConnectModal,
+      closeWalletConnectModal,
     };
   }, [
-    walletConnection,
+    walletConnection.isWalletConnected,
+    walletConnection.rdns,
     availableProviders,
     activeChat,
     conversationHistories,
@@ -367,5 +386,8 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     detectProviders,
     handleProviderSelect,
     disconnectWallet,
+    isWalletConnectOpen,
+    openWalletConnectModal,
+    closeWalletConnectModal,
   ]);
 };

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -120,6 +120,11 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     [connectEIP6963Provider],
   );
 
+  const onProviderSelect = async (provider: WalletProviderDetail) => {
+    await handleProviderSelect(provider);
+    closeWalletConnectModal();
+  };
+
   const setIsOperationValidated = useCallback(
     (isOperationValidated: boolean) => {
       setActiveChat((prev) => {
@@ -365,6 +370,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       isWalletModalOpen,
       openWalletConnectModal,
       closeWalletConnectModal,
+      onProviderSelect,
     };
   }, [
     walletConnection.isWalletConnected,
@@ -386,5 +392,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     isWalletModalOpen,
     openWalletConnectModal,
     closeWalletConnectModal,
+    onProviderSelect,
   ]);
 };

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -48,11 +48,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
 
   const [isWalletConnectOpen, setIsWalletConnectOpen] = useState(false);
 
-  const openWalletConnectModal = () => {
-    refreshProviders();
-    setIsWalletConnectOpen(true);
-  };
-
   // **********
   const [activeChat, setActiveChat] = useState<ActiveChat>({
     id: uuidv4(), // add uuid v4 for conversation id
@@ -79,10 +74,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     WalletProviderDetail[]
   >([]);
 
-  const refreshProviders = useCallback(() => {
-    setAvailableProviders(walletStore.getProviders());
-  }, []);
-
   const connectEIP6963Provider = useCallback(
     async (providerId: string, chainId?: string) => {
       try {
@@ -99,9 +90,14 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     [],
   );
 
-  const detectProviders = useCallback(async () => {
+  const refreshProviders = useCallback(() => {
+    setAvailableProviders(walletStore.getProviders());
+  }, []);
+
+  const openWalletConnectModal = useCallback(() => {
     refreshProviders();
-  }, [refreshProviders]);
+    setIsWalletConnectOpen(true);
+  }, [refreshProviders, setIsWalletConnectOpen]);
 
   const disconnectWallet = useCallback(() => {
     walletStore.disconnectWallet();
@@ -359,7 +355,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       fetchSearchHistory,
       toolCallRegistry,
       walletAddress,
-      detectProviders,
       handleProviderSelect,
       disconnectWallet,
       availableProviders,
@@ -383,7 +378,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     searchableHistory,
     toolCallRegistry,
     walletAddress,
-    detectProviders,
     handleProviderSelect,
     disconnectWallet,
     isWalletConnectOpen,

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -120,11 +120,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     [connectEIP6963Provider],
   );
 
-  const onProviderSelect = async (provider: WalletProviderDetail) => {
-    await handleProviderSelect(provider);
-    closeWalletConnectModal();
-  };
-
   const setIsOperationValidated = useCallback(
     (isOperationValidated: boolean) => {
       setActiveChat((prev) => {
@@ -151,6 +146,14 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       handleModalClose();
     }
   }, [handleModalClose]);
+
+  const onProviderSelect = useCallback(
+    async (provider: WalletProviderDetail) => {
+      await handleProviderSelect(provider);
+      closeWalletConnectModal();
+    },
+    [handleProviderSelect, closeWalletConnectModal],
+  );
 
   const fetchConversations = useCallback(() => {
     getAllConversations()

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -172,9 +172,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       if (newActiveChat.messageHistoryStore.getSnapshot().length === 0) {
         newActiveChat.messageHistoryStore.addMessage({
           role: 'system',
-          content: defaultSystemPrompt.concat(
-            `Here is important information about the user: Wallet address: ${walletStore.getSnapshot().walletAddress} Connected Chain: ${parseInt(walletStore.getSnapshot().walletChainId, 16)}`,
-          ),
+          content: defaultSystemPrompt,
         });
       }
       // update isRequesting state and create a new abortController

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -46,8 +46,6 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
   const [conversationHistories, setConversationHistories] =
     useState<ConversationHistories | null>(null);
 
-  const [isWalletConnectOpen, setIsWalletConnectOpen] = useState(false);
-
   // **********
   const [activeChat, setActiveChat] = useState<ActiveChat>({
     id: uuidv4(), // add uuid v4 for conversation id
@@ -74,6 +72,9 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     WalletProviderDetail[]
   >([]);
 
+  const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
+  const [isWalletConnecting, setIsWalletConnecting] = useState(false);
+
   const connectEIP6963Provider = useCallback(
     async (providerId: string, chainId?: string) => {
       try {
@@ -96,8 +97,8 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
 
   const openWalletConnectModal = useCallback(() => {
     refreshProviders();
-    setIsWalletConnectOpen(true);
-  }, [refreshProviders, setIsWalletConnectOpen]);
+    setIsWalletModalOpen(true);
+  }, [refreshProviders, setIsWalletModalOpen]);
 
   const disconnectWallet = useCallback(() => {
     walletStore.disconnectWallet();
@@ -135,10 +136,12 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     activeChat.isOperationValidated,
     setIsOperationValidated,
     openWalletConnectModal,
+    isWalletConnecting,
+    setIsWalletConnecting,
   );
 
   const closeWalletConnectModal = useCallback(() => {
-    setIsWalletConnectOpen(false);
+    setIsWalletModalOpen(false);
     if (handleModalClose) {
       handleModalClose();
     }
@@ -169,7 +172,9 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       if (newActiveChat.messageHistoryStore.getSnapshot().length === 0) {
         newActiveChat.messageHistoryStore.addMessage({
           role: 'system',
-          content: defaultSystemPrompt,
+          content: defaultSystemPrompt.concat(
+            `Here is important information about the user: Wallet address: ${walletStore.getSnapshot().walletAddress} Connected Chain: ${parseInt(walletStore.getSnapshot().walletChainId, 16)}`,
+          ),
         });
       }
       // update isRequesting state and create a new abortController
@@ -359,7 +364,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
       disconnectWallet,
       availableProviders,
       walletProviderInfo,
-      isWalletConnectOpen,
+      isWalletModalOpen,
       openWalletConnectModal,
       closeWalletConnectModal,
     };
@@ -380,7 +385,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     walletAddress,
     handleProviderSelect,
     disconnectWallet,
-    isWalletConnectOpen,
+    isWalletModalOpen,
     openWalletConnectModal,
     closeWalletConnectModal,
   ]);

--- a/src/useExecuteToolCall.tsx
+++ b/src/useExecuteToolCall.tsx
@@ -103,7 +103,7 @@ export const useExecuteToolCall = (
 
       throw new Error('Invalid operation type');
     },
-    [setIsOperationValidated], // Add dependencies here
+    [setIsOperationValidated],
   );
 
   /**
@@ -112,7 +112,7 @@ export const useExecuteToolCall = (
   const waitForWalletConnection = useCallback(
     async (operation: ChainToolCallOperation<unknown>) => {
       return new Promise((resolve, reject) => {
-        // Store the reject function so we can call it if modal is closed
+        //  Store the reject function so we can call it if modal is closed
         modalRef.current.rejectConnection = reject;
 
         const unsubscribe = walletStore.subscribe(() => {
@@ -128,7 +128,7 @@ export const useExecuteToolCall = (
           }
         });
 
-        // The user has 5 minutes to connect (as a fallback)
+        //  The user has 5 minutes to connect (as a fallback)
         const timeoutId = setTimeout(() => {
           unsubscribe();
           modalRef.current.isOpen = false;
@@ -136,13 +136,11 @@ export const useExecuteToolCall = (
           reject(new Error('Wallet connection timed out'));
         }, 300000);
 
-        // Cleanup function
         const cleanup = () => {
           clearTimeout(timeoutId);
           unsubscribe();
         };
 
-        // Store cleanup function to be called on promise resolution or rejection
         (async () => {
           try {
             await Promise.resolve();

--- a/src/useExecuteToolCall.tsx
+++ b/src/useExecuteToolCall.tsx
@@ -227,6 +227,7 @@ export const useExecuteToolCall = (
       walletStore,
       completeOperation,
       openModal,
+      waitForWalletConnection,
     ],
   );
 

--- a/src/useExecuteToolCall.tsx
+++ b/src/useExecuteToolCall.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { WalletStore, WalletTypes } from './stores/walletStore';
 import {
   ChainNames,
@@ -18,9 +18,9 @@ export const useExecuteToolCall = (
   isOperationValidated: boolean,
   setIsOperationValidated: (isOperationValidated: boolean) => void,
   openWalletConnectModal: () => void,
+  isWalletConnecting: boolean,
+  setIsWalletConnecting: (isWalletConnecting: boolean) => void,
 ) => {
-  const [isWalletConnecting, setIsWalletConnecting] = useState(false);
-
   //  Reference to track connect wallet modal state
   const modalRef = useRef({
     isOpen: false,
@@ -226,6 +226,7 @@ export const useExecuteToolCall = (
       registry,
       walletStore,
       completeOperation,
+      setIsWalletConnecting,
       openModal,
       waitForWalletConnection,
     ],
@@ -235,6 +236,6 @@ export const useExecuteToolCall = (
     executeOperation,
     isOperationValidated,
     isWalletConnecting,
-    handleModalClose, // Export this so it can be attached to your modal's onClose event
+    handleModalClose,
   };
 };


### PR DESCRIPTION
# Wallet Connect UX Demo

## Overview
This demo showcases an improved UX for connecting wallets to HardAI. It implements the EIP-6963 standard to discover and display all compatible wallet providers installed on a user's device.

## Features

### EIP-6963 Wallet Discovery
- Automatically detects all EIP-6963 compatible wallet providers installed in the user's browser
- Displays all discovered wallets (any wallet that implements the EIP-6963 standard) as connection options in a modal

https://github.com/user-attachments/assets/8e85f5e4-c69a-4c2e-ad4a-766aec5547da

### Promoted Wallet Options
- Prominently displays MetaMask and HOT Wallet as recommended options
- Provides direct download links if these promoted wallets aren't already installed

https://github.com/user-attachments/assets/5fce9eb2-7e13-41dd-920f-92c3549e9fd3

https://github.com/user-attachments/assets/b6705a13-f48d-48c0-8396-eb04a49d03eb


### Tool Call Integration
- Prompts for wallet connection when a user attempts a tool call requiring wallet access

https://github.com/user-attachments/assets/228f3bbb-7e4d-48a0-8e73-11a33c935e00


### Error Handling
- Manages various connection scenarios:
  - User explicitly rejects the connection in their wallet
  - User closes the modal without connecting
  - Connection attempt times out (after 5 minutes)
- Returns helpful error messages via the LLM to guide users when connection fails

https://github.com/user-attachments/assets/13d3cc6e-6fb7-433a-8af8-99098257d4ec

### What's Next/Open Questions
- Persisting wallet connection: keep a user connected if they refresh the page
- If you start a new chat with a connected wallet, should connection persist or reset?
- If multiple wallets are eventually connected simulatenously, does the concept of "active wallet" still hold? 
- Is wallet connection global or conversation specific?
  - If I change to an old conversation that used a wallet, what is the UX on re-establishing that connection?
     - initially naive: reopen the connect wallet modal with only the supported option enabled
     - eventually seemless: selecting an old conversation requests the matching account
- Mobile support: 
   - MetaMask: users can download extension & use the app _within_ the extension only - not an incredibly intuitive workflow for first time users
   - HOT Wallet: Android-only mobile app






