### PR TITLE
feat: allow sending from nonactive address

### DIFF
--- a/src/toolcalls/evmTransfer.ts
+++ b/src/toolcalls/evmTransfer.ts
@@ -19,6 +19,7 @@ import { InProgressTxDisplay } from './components/InProgressTxDisplay';
 interface SendToolParams {
   chainName: string;
   toAddress: string;
+  fromAddress?: string;
   amount: string;
   denom: string;
 }
@@ -41,6 +42,12 @@ export class EvmTransferMessage
       type: 'string',
       description: 'Recipient address',
       required: true,
+    },
+    {
+      name: 'fromAddress',
+      type: 'string',
+      description: 'Sending address',
+      required: false,
     },
     {
       name: 'amount',
@@ -123,9 +130,6 @@ export class EvmTransferMessage
 
     const { toAddress, amount, denom } = params;
 
-    // const { masksToValues } = getStoredMasks();
-
-    // const validToAddress = masksToValues[toAddress] ?? '';
     const validToAddress = toAddress;
     if (!validToAddress.length) {
       throw new Error(`please provide a valid address to send to`);
@@ -163,7 +167,7 @@ export class EvmTransferMessage
     }
 
     const { ethers } = await import('ethers');
-    const { toAddress, amount, denom } = params;
+    const { toAddress, fromAddress, amount, denom } = params;
 
     const { erc20Contracts, rpcUrls, nativeToken, chainID } = chainRegistry[
       this.chainType
@@ -174,7 +178,8 @@ export class EvmTransferMessage
       let txParams: Record<string, string>;
 
       const addressTo = toAddress;
-      const addressFrom = walletStore.getSnapshot().walletAddress;
+      const addressFrom =
+        fromAddress ?? walletStore.getSnapshot().walletAddress;
 
       const receivingAddress = ethers.getAddress(addressTo);
       const sendingAddress = ethers.getAddress(addressFrom);


### PR DESCRIPTION
Update `evmTransfer` tool call to include an optional `fromAddress` parameter which enables the user to send from a permissioned, but not currently-connected account. If its not included, then assume the currently connected wallet will sign.

Workflows
A1. User connects Wallet A
A2. User requests "Send 10 KAVA from Wallet B to Wallet A"

B1. User connects Wallet A
B2. User requests "Send 10 KAVA to Wallet B" (assumes Wallet A is from address)

https://github.com/user-attachments/assets/cf888e27-3880-4f77-8bb7-8d095c4796e6

