### PR TITLE
feat: save uuid for walletType in local storage

### DIFF
--- a/src/stores/walletStore/walletStore.test.tsx
+++ b/src/stores/walletStore/walletStore.test.tsx
@@ -327,7 +327,7 @@ describe('walletStore', () => {
       }),
     );
   });
-  test('should save wallet type to localStorage when connecting', async () => {
+  test('should save wallet uuid to localStorage when connecting', async () => {
     announceProvider(metamask);
 
     await walletStore.connectWallet({
@@ -341,7 +341,7 @@ describe('walletStore', () => {
     );
   });
 
-  test('should clear wallet type in localStorage when disconnecting', async () => {
+  test('should clear wallet uuid in localStorage when disconnecting', async () => {
     announceProvider(metamask);
 
     await walletStore.connectWallet({
@@ -357,7 +357,7 @@ describe('walletStore', () => {
     expect(localStorageMock.setItem).toHaveBeenCalledWith('walletType', '');
   });
 
-  test('should update wallet type in localStorage when switching wallets', async () => {
+  test('should update wallet uuid in localStorage when switching wallets', async () => {
     announceProvider(metamask);
 
     await walletStore.connectWallet({
@@ -392,7 +392,7 @@ describe('walletStore', () => {
     );
   });
 
-  test('should not update wallet type in localStorage when only accounts change', async () => {
+  test('should not update wallet uuid in localStorage when only accounts change', async () => {
     announceProvider(metamask);
 
     await walletStore.connectWallet({

--- a/src/stores/walletStore/walletStore.test.tsx
+++ b/src/stores/walletStore/walletStore.test.tsx
@@ -106,11 +106,37 @@ async function simulateChainChanged(
   );
 }
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    getAll: () => store,
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
 describe('walletStore', () => {
+  let metamask: EIP6963ProviderDetail;
+
   beforeEach(() => {
     walletStore.disconnectWallet();
     vi.useFakeTimers();
     vi.clearAllMocks();
+    localStorageMock.clear();
+    metamask = mockEIP6963Provider({
+      name: 'MetaMask',
+      uuid: 'metamask-uuid',
+    });
   });
 
   afterEach(() => {
@@ -300,5 +326,94 @@ describe('walletStore', () => {
         method: 'eth_chainId',
       }),
     );
+  });
+  test('should save wallet type to localStorage when connecting', async () => {
+    announceProvider(metamask);
+
+    await walletStore.connectWallet({
+      walletProvider: WalletProvider.EIP6963,
+      providerId: 'metamask-uuid',
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'walletType',
+      'MetaMask',
+    );
+  });
+
+  test('should clear wallet type in localStorage when disconnecting', async () => {
+    announceProvider(metamask);
+
+    await walletStore.connectWallet({
+      walletProvider: WalletProvider.EIP6963,
+      providerId: 'metamask-uuid',
+    });
+
+    //  Clear mock call history after connect
+    localStorageMock.setItem.mockClear();
+
+    walletStore.disconnectWallet();
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('walletType', '');
+  });
+
+  test('should update wallet type in localStorage when switching wallets', async () => {
+    announceProvider(metamask);
+
+    await walletStore.connectWallet({
+      walletProvider: WalletProvider.EIP6963,
+      providerId: 'metamask-uuid',
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'walletType',
+      'MetaMask',
+    );
+
+    localStorageMock.setItem.mockClear();
+
+    //  Connect to a different wallet
+    const keplr = mockEIP6963Provider({
+      name: 'Keplr',
+      uuid: 'keplr-uuid',
+      rdns: 'io.keplr',
+    });
+
+    announceProvider(keplr);
+
+    await walletStore.connectWallet({
+      walletProvider: WalletProvider.EIP6963,
+      providerId: 'keplr-uuid',
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'walletType',
+      'Keplr',
+    );
+  });
+
+  test('should not update wallet type in localStorage when only accounts change', async () => {
+    announceProvider(metamask);
+
+    await walletStore.connectWallet({
+      walletProvider: WalletProvider.EIP6963,
+      providerId: 'metamask-uuid',
+    });
+
+    expect(localStorageMock.setItem.mock.calls.length).toBe(1);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'walletType',
+      'MetaMask',
+    );
+
+    //  Change accounts but keep the same wallet
+    await simulateAccountsChanged(metamask.provider, [
+      '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+    ]);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    //  setItem is not called again since it's the same wallet type
+    expect(localStorageMock.setItem.mock.calls.length).toBe(1);
   });
 });

--- a/src/stores/walletStore/walletStore.test.tsx
+++ b/src/stores/walletStore/walletStore.test.tsx
@@ -337,7 +337,7 @@ describe('walletStore', () => {
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'MetaMask',
+      'metamask-uuid',
     );
   });
 
@@ -367,7 +367,7 @@ describe('walletStore', () => {
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'MetaMask',
+      'metamask-uuid',
     );
 
     localStorageMock.setItem.mockClear();
@@ -388,7 +388,7 @@ describe('walletStore', () => {
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'Keplr',
+      'keplr-uuid',
     );
   });
 
@@ -403,7 +403,7 @@ describe('walletStore', () => {
     expect(localStorageMock.setItem.mock.calls.length).toBe(1);
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'MetaMask',
+      'metamask-uuid',
     );
 
     //  Change accounts but keep the same wallet

--- a/src/stores/walletStore/walletStore.ts
+++ b/src/stores/walletStore/walletStore.ts
@@ -7,7 +7,6 @@ import {
 
 type Listener = () => void;
 
-// Define the local storage key constant
 const WALLET_TYPE_STORAGE_KEY = 'walletType';
 
 export enum WalletProvider {

--- a/src/stores/walletStore/walletStore.ts
+++ b/src/stores/walletStore/walletStore.ts
@@ -107,9 +107,9 @@ export class WalletStore {
     this.setupChangeListeners();
   }
 
-  private saveWalletTypeToStorage(walletType: string) {
+  private saveWalletTypeToStorage(uuid: string) {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, walletType);
+      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, uuid);
     }
   }
 
@@ -370,10 +370,10 @@ export class WalletStore {
 
         const {
           provider,
-          info: { rdns, name },
+          info: { rdns, name, uuid },
         } = providerDetail;
 
-        this.saveWalletTypeToStorage(name);
+        this.saveWalletTypeToStorage(uuid);
 
         this.currentValue = {
           walletAddress: accounts[0],

--- a/src/stores/walletStore/walletStore.ts
+++ b/src/stores/walletStore/walletStore.ts
@@ -7,6 +7,9 @@ import {
 
 type Listener = () => void;
 
+// Define the local storage key constant
+const WALLET_TYPE_STORAGE_KEY = 'walletType';
+
 export enum WalletProvider {
   EIP6963 = 'EIP6963',
   NONE = 'NONE',
@@ -103,6 +106,18 @@ export class WalletStore {
   constructor() {
     this.setupEIP6963Listeners();
     this.setupChangeListeners();
+  }
+
+  private saveWalletTypeToStorage(walletType: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, walletType);
+    }
+  }
+
+  private clearWalletTypeFromStorage() {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, '');
+    }
   }
 
   private setupEIP6963Listeners() {
@@ -280,7 +295,9 @@ export class WalletStore {
       }
     }
   }
+
   public disconnectWallet() {
+    this.clearWalletTypeFromStorage();
     this.currentValue = {
       walletAddress: '',
       walletChainId: '',
@@ -356,6 +373,8 @@ export class WalletStore {
           provider,
           info: { rdns, name },
         } = providerDetail;
+
+        this.saveWalletTypeToStorage(name);
 
         this.currentValue = {
           walletAddress: accounts[0],


### PR DESCRIPTION
## Summary

Store the uuid of the most recently connected wallet in local storage. This will eventually be used to detect which wallet the app should reconnect to when the user refreshes the page.

