### PR TITLE
refactor: use rdns instead of id for wallet connection/selection

### DIFF
--- a/src/stores/walletStore/walletStore.test.tsx
+++ b/src/stores/walletStore/walletStore.test.tsx
@@ -15,9 +15,9 @@ function mockEIP6963Provider(
   options: MockProviderOptions = {},
 ): EIP6963ProviderDetail {
   const {
-    name = 'Mock Wallet',
+    name = 'MetaMask',
     uuid = 'mock-uuid',
-    rdns = 'com.mock.wallet',
+    rdns = 'io.metamask',
     icon = 'data:image/svg+xml,mock-icon',
     accounts = ['0x123456789abcdef0123456789abcdef01234567'],
     chainId = '0x8ae',
@@ -167,26 +167,20 @@ describe('walletStore', () => {
   });
 
   test('should connect to a selected provider', async () => {
-    const metamask = mockEIP6963Provider({
-      name: 'MetaMask',
-      uuid: 'metamask-uuid',
-      accounts: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-    });
-
     announceProvider(metamask);
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
       chainId: '0x8ae', // Chain ID 2222
     });
 
     const state = walletStore.getSnapshot();
     expect(state.isWalletConnected).toBe(true);
     expect(state.walletAddress).toBe(
-      '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      '0x123456789abcdef0123456789abcdef01234567',
     );
-    expect(state.rdns).toBe('com.mock.wallet');
+    expect(state.rdns).toBe('io.metamask');
 
     expect(metamask.provider.request).toHaveBeenCalledWith({
       method: 'eth_requestAccounts',
@@ -194,21 +188,15 @@ describe('walletStore', () => {
   });
 
   test('should handle account changes from wallet', async () => {
-    const metamask = mockEIP6963Provider({
-      name: 'MetaMask',
-      uuid: 'metamask-uuid',
-      accounts: ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'],
-    });
-
     announceProvider(metamask);
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(walletStore.getSnapshot().walletAddress).toBe(
-      '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      '0x123456789abcdef0123456789abcdef01234567',
     );
 
     expect(metamask.provider.on).toHaveBeenCalledWith(
@@ -225,17 +213,11 @@ describe('walletStore', () => {
   });
 
   test('should handle chain changes from wallet', async () => {
-    const metamask = mockEIP6963Provider({
-      name: 'MetaMask',
-      uuid: 'metamask-uuid',
-      chainId: '0x8ae', // Chain ID 2222
-    });
-
     announceProvider(metamask);
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(walletStore.getSnapshot().walletChainId).toBe('0x8ae');
@@ -254,16 +236,11 @@ describe('walletStore', () => {
   });
 
   test('should disconnect wallet', async () => {
-    const metamask = mockEIP6963Provider({
-      name: 'MetaMask',
-      uuid: 'metamask-uuid',
-    });
-
     announceProvider(metamask);
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(walletStore.getSnapshot().isWalletConnected).toBe(true);
@@ -278,7 +255,7 @@ describe('walletStore', () => {
   test('should handle connection rejection', async () => {
     const rejectingProvider = mockEIP6963Provider({
       name: 'Rejecting Wallet',
-      uuid: 'rejecting-wallet',
+      rdns: 'io.blub',
     });
 
     rejectingProvider.provider.request = vi
@@ -295,7 +272,7 @@ describe('walletStore', () => {
     await expect(
       walletStore.connectWallet({
         walletProvider: WalletProvider.EIP6963,
-        providerId: 'rejecting-wallet',
+        rdns: 'io.blub',
       }),
     ).rejects.toThrow('User rejected the request');
 
@@ -307,7 +284,7 @@ describe('walletStore', () => {
   test('should handle chain switching', async () => {
     const wrongChainProvider = mockEIP6963Provider({
       name: 'Wrong Chain Wallet',
-      uuid: 'wrong-chain-wallet',
+      rdns: 'io.new-wallet',
       chainId: '0x1', // Ethereum mainnet
     });
 
@@ -317,7 +294,7 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'wrong-chain-wallet',
+      rdns: 'io.new-wallet',
       chainId: '0x8ae', // Chain ID 2222
     });
 
@@ -332,12 +309,12 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'metamask-uuid',
+      'io.metamask',
     );
   });
 
@@ -346,7 +323,7 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     //  Clear mock call history after connect
@@ -362,12 +339,12 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'metamask-uuid',
+      'io.metamask',
     );
 
     localStorageMock.setItem.mockClear();
@@ -383,12 +360,12 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'keplr-uuid',
+      rdns: 'io.keplr',
     });
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'keplr-uuid',
+      'io.keplr',
     );
   });
 
@@ -397,13 +374,13 @@ describe('walletStore', () => {
 
     await walletStore.connectWallet({
       walletProvider: WalletProvider.EIP6963,
-      providerId: 'metamask-uuid',
+      rdns: 'io.metamask',
     });
 
     expect(localStorageMock.setItem.mock.calls.length).toBe(1);
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       'walletType',
-      'metamask-uuid',
+      'io.metamask',
     );
 
     //  Change accounts but keep the same wallet

--- a/src/stores/walletStore/walletStore.ts
+++ b/src/stores/walletStore/walletStore.ts
@@ -347,6 +347,7 @@ export class WalletStore {
   };
 
   private findProviderByRdns(rdns: string): EIP6963ProviderDetail | undefined {
+    console.log(this.providers);
     for (const [_, providerDetail] of this.providers) {
       if (providerDetail.info.rdns === rdns) {
         return providerDetail;

--- a/src/stores/walletStore/walletStore.ts
+++ b/src/stores/walletStore/walletStore.ts
@@ -107,9 +107,9 @@ export class WalletStore {
     this.setupChangeListeners();
   }
 
-  private saveWalletTypeToStorage(uuid: string) {
+  private saveWalletTypeToStorage(rdns: string) {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, uuid);
+      localStorage.setItem(WALLET_TYPE_STORAGE_KEY, rdns);
     }
   }
 
@@ -179,12 +179,12 @@ export class WalletStore {
   public async connectWallet(opts: {
     chainId?: string;
     walletProvider: WalletProvider;
-    providerId?: string;
+    rdns?: string;
   }) {
     switch (opts.walletProvider) {
       case WalletProvider.EIP6963: {
-        if (opts.providerId) {
-          await this.connectEIP6963Provider(opts.providerId);
+        if (opts.rdns) {
+          await this.connectEIP6963Provider(opts.rdns);
         }
         break;
       }
@@ -346,12 +346,21 @@ export class WalletStore {
     };
   };
 
-  private async connectEIP6963Provider(providerId: string) {
-    const providerDetail = this.providers.get(providerId);
+  private findProviderByRdns(rdns: string): EIP6963ProviderDetail | undefined {
+    for (const [_, providerDetail] of this.providers) {
+      if (providerDetail.info.rdns === rdns) {
+        return providerDetail;
+      }
+    }
+    return undefined;
+  }
+
+  private async connectEIP6963Provider(rdns: string) {
+    const providerDetail = this.findProviderByRdns(rdns);
 
     if (!providerDetail) {
-      console.error(`Provider with UUID ${providerId} not found`);
-      throw new Error(`Provider with UUID ${providerId} not found`);
+      console.error(`Provider with rdns ${rdns} not found`);
+      throw new Error(`Provider with rdns ${rdns} not found`);
     }
 
     try {
@@ -370,10 +379,10 @@ export class WalletStore {
 
         const {
           provider,
-          info: { rdns, name, uuid },
+          info: { rdns, name },
         } = providerDetail;
 
-        this.saveWalletTypeToStorage(uuid);
+        this.saveWalletTypeToStorage(rdns);
 
         this.currentValue = {
           walletAddress: accounts[0],

--- a/src/useChat.tsx
+++ b/src/useChat.tsx
@@ -162,8 +162,9 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     },
     [activeChat],
   );
+
   const connectEIP6963Provider = useCallback(
-    async (providerId: string, chainId?: string) => {
+    async (rdns: string, chainId?: string) => {
       if (walletUpdateRef.current.isProcessing) return;
       walletUpdateRef.current.isProcessing = true;
 
@@ -171,7 +172,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
         await walletStore.connectWallet({
           chainId,
           walletProvider: WalletProvider.EIP6963,
-          providerId,
+          rdns,
         });
 
         const walletInfo = await getCurrentWalletInfoForPrompt();
@@ -266,7 +267,7 @@ export const useChat = (initValues?: ChatMessage[], initModel?: string) => {
     async (provider: EIP6963ProviderDetail) => {
       try {
         await connectEIP6963Provider(
-          provider.info.uuid,
+          provider.info.rdns,
           `0x${Number(2222).toString(16)}`,
         );
       } catch (err) {


### PR DESCRIPTION
Since the ID announced by the EIP-6963 provider isn't deterministic, let's use the rdns (reverse DNS) as the argument we use to select and connect to the provider.

The end goal is to store the RDNS in of the previously connected wallet in local storage so we can reconnect to that wallet on refresh/revisit.

Using the UUID isn't possible since the metamask id won't be the same across different visits to the page. 


#### Wallet connection still works

https://github.com/user-attachments/assets/e1c455e3-28e9-41e9-ba78-d615d38a57fd


