### PR TITLE
feat: add basic chat settings dialog (read-only)

### DIFF
--- a/src/ChatInput.module.css
+++ b/src/ChatInput.module.css
@@ -4,6 +4,7 @@
   position: relative;
   min-height: 0;
   flex: 1;
+  gap: var(--spacing-sm);
 }
 
 .input {
@@ -19,7 +20,7 @@
   text-wrap: wrap;
   min-height: 30px;
   padding-top: 4px;
-  padding-bottom: 3.2rem; /* Add bottom padding to make room for settings button */
+  padding-bottom: 4px;
   scrollbar-color: var(--colors-textMuted) var(--colors-bgTertiary);
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
@@ -88,4 +89,11 @@
   font-size: 1.2rem;
   text-align: center;
   color: var(--colors-textMuted);
+}
+
+/* Mobile optimization */
+@media (max-width: 768px) {
+  .inputContainer {
+    padding-left: calc(36px + var(--spacing-sm)); /* Smaller button on mobile */
+  }
 }

--- a/src/ChatInput.module.css
+++ b/src/ChatInput.module.css
@@ -19,6 +19,7 @@
   text-wrap: wrap;
   min-height: 30px;
   padding-top: 4px;
+  padding-bottom: 3.2rem; /* Add bottom padding to make room for settings button */
   scrollbar-color: var(--colors-textMuted) var(--colors-bgTertiary);
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;

--- a/src/ChatInput.tsx
+++ b/src/ChatInput.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { SendChatIcon } from './SendChatIcon';
 import { ChatMessage } from './types';
 import { CancelChatIcon } from './CancelChatIcon';
+import { ChatSettingsButton } from './ChatSettings';
 
 const DEFAULT_HEIGHT = '30px';
 
@@ -62,6 +63,7 @@ export const ChatInput = ({
     <>
       <div className={styles.controls}>
         <div className={styles.inputContainer}>
+          <ChatSettingsButton />
           <textarea
             className={styles.input}
             rows={1}

--- a/src/ChatSettings.module.css
+++ b/src/ChatSettings.module.css
@@ -1,0 +1,190 @@
+.chatSettingsButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background-color: var(--colors-bgTertiary);
+  border: 1px solid var(--colors-borderSecondary);
+  border-radius: var(--borderRadius-sm);
+  color: var(--colors-textSecondary);
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  padding: 0;
+  margin: 0;
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  top: 5px;
+}
+
+.chatSettingsButton:hover {
+  background-color: var(--colors-bgQuaternary);
+  border-color: var(--colors-borderPrimary);
+  color: var(--colors-textPrimary);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.chatSettingsButton:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.chatSettingsButton:focus {
+  outline: 2px solid var(--colors-accent);
+  outline-offset: 2px;
+}
+
+.chatSettingsButton:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Icon styling */
+.chatSettingsButton svg {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.2s ease-in-out;
+}
+
+.chatSettingsButton:hover svg {
+  transform: rotate(90deg);
+}
+
+/* Loading state */
+.chatSettingsButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.chatSettingsButton:disabled:hover {
+  background-color: var(--colors-bgTertiary);
+  border-color: var(--colors-borderSecondary);
+  color: var(--colors-textSecondary);
+  transform: none;
+  box-shadow: none;
+}
+
+.chatSettingsButton:disabled svg {
+  transform: none;
+}
+
+/* Mobile optimization */
+@media (max-width: 768px) {
+  .chatSettingsButton {
+    width: 36px;
+    height: 36px;
+  }
+
+  .chatSettingsButton svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .chatSettingsButton {
+    border-width: 2px;
+  }
+
+  .chatSettingsButton:focus {
+    outline-width: 3px;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .chatSettingsButton,
+  .chatSettingsButton:hover,
+  .chatSettingsButton:active,
+  .chatSettingsButton svg {
+    transition: none;
+    transform: none;
+  }
+}
+
+/* Modal content styles */
+.modalContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.sectionTitle {
+  color: var(--colors-textPrimary);
+  font-size: 2rem;
+  font-weight: var(--typography-fontWeightBold);
+  margin: 0;
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--colors-borderSecondary);
+}
+
+.sectionDescription {
+  color: var(--colors-textSecondary);
+  font-size: 1.4rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.subsectionTitle {
+  color: var(--colors-textPrimary);
+  font-size: 1.6rem;
+  font-weight: var(--typography-fontWeightBold);
+  margin: 0;
+}
+
+.aboutText {
+  color: var(--colors-textSecondary);
+  font-size: 1.4rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.promptContainer {
+  background-color: var(--colors-bgTertiary);
+  border: 1px solid var(--colors-borderSecondary);
+  border-radius: var(--borderRadius-sm);
+  padding: var(--spacing-md);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.promptText {
+  color: var(--colors-textSecondary);
+  font-size: 1.2rem;
+  line-height: 1.6;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* Scrollbar styling for prompt container */
+.promptContainer::-webkit-scrollbar {
+  width: 8px;
+}
+
+.promptContainer::-webkit-scrollbar-track {
+  background: var(--colors-bgSecondary);
+  border-radius: var(--borderRadius-xs);
+}
+
+.promptContainer::-webkit-scrollbar-thumb {
+  background: var(--colors-borderSecondary);
+  border-radius: var(--borderRadius-xs);
+}
+
+.promptContainer::-webkit-scrollbar-thumb:hover {
+  background: var(--colors-borderPrimary);
+}

--- a/src/ChatSettings.module.css
+++ b/src/ChatSettings.module.css
@@ -2,8 +2,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 40px;
+  height: 40px;
   background-color: var(--colors-bgTertiary);
   border: 1px solid var(--colors-borderSecondary);
   border-radius: var(--borderRadius-sm);
@@ -13,9 +13,9 @@
   padding: 0;
   margin: 0;
   outline: none;
-  position: relative;
+    position: relative;
   overflow: hidden;
-  top: 5px;
+  flex-shrink: 0;
 }
 
 .chatSettingsButton:hover {

--- a/src/ChatSettings.tsx
+++ b/src/ChatSettings.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ModalButton } from './components/Modal';
+import { defaultSystemPrompt } from './toolcalls/chain/prompts';
+import { Cog } from 'lucide-react';
+import styles from './ChatSettings.module.css';
+
+const ChatSettingsModal: React.FC = () => {
+  return (
+    <div className={styles.modalContent}>
+      <div className={styles.section}>
+        <h4 className={styles.sectionTitle}>System Prompt</h4>
+        <p className={styles.sectionDescription}>
+          This is the current system prompt that defines how KavaAI behaves and
+          responds to your queries.
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.promptContainer}>
+          <pre className={styles.promptText}>{defaultSystemPrompt}</pre>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ChatSettingsButton = () => (
+  <ModalButton
+    className={styles.chatSettingsButton}
+    modalTitle="Settings"
+    modalContent={<ChatSettingsModal />}
+  >
+    <Cog />
+  </ModalButton>
+);

--- a/src/WalletModal.tsx
+++ b/src/WalletModal.tsx
@@ -31,6 +31,7 @@ const WalletModal: React.FC<WalletModalProps> = ({ onClose }) => {
     <Modal
       title={hasProviders ? 'Select a Wallet' : 'Get a Wallet'}
       onClose={onClose}
+      maxWidth="32rem"
     >
       <div className={styles.providersList}>
         {hasProviders &&

--- a/src/components/Modal.module.css
+++ b/src/components/Modal.module.css
@@ -67,7 +67,6 @@
 
   .modal {
     width: 90%;
-    max-width: 32rem;
     height: auto;
     max-height: 80vh;
     border-radius: var(--borderRadius-sm);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,15 +1,21 @@
-import React, { useEffect, useRef } from 'react';
-import styles from './Modal.module.css';
 import { ButtonIcon } from 'lib-kava-ai';
 import { X } from 'lucide-react';
+import React, { useEffect, useRef } from 'react';
+import styles from './Modal.module.css';
 
 interface ModalProps {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  maxWidth?: React.CSSProperties['maxWidth'];
 }
 
-const Modal: React.FC<ModalProps> = ({ title, onClose, children }) => {
+const Modal: React.FC<ModalProps> = ({
+  title,
+  onClose,
+  maxWidth,
+  children,
+}) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -31,7 +37,7 @@ const Modal: React.FC<ModalProps> = ({ title, onClose, children }) => {
 
   return (
     <div className={styles.modalBackdrop}>
-      <div className={styles.modal} ref={modalRef}>
+      <div className={styles.modal} ref={modalRef} style={{ maxWidth }}>
         <div className={styles.modalHeader}>
           <h3>{title}</h3>
           <ButtonIcon icon={X} aria-label={'Close modal'} onClick={onClose} />
@@ -48,9 +54,10 @@ export const ModalButton: React.FC<
   React.PropsWithChildren<{
     className?: string;
     modalTitle: string;
-    modalContent: string;
+    modalContent: React.ReactNode;
+    modalMaxWidth?: React.CSSProperties['maxWidth'];
   }>
-> = ({ children, modalTitle, modalContent, className }) => {
+> = ({ children, modalTitle, modalContent, className, modalMaxWidth }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   return (
     <>
@@ -58,7 +65,11 @@ export const ModalButton: React.FC<
         {children}
       </button>
       {isOpen && (
-        <Modal title={modalTitle} onClose={() => setIsOpen(false)}>
+        <Modal
+          title={modalTitle}
+          onClose={() => setIsOpen(false)}
+          maxWidth={modalMaxWidth}
+        >
           {modalContent}
         </Modal>
       )}


### PR DESCRIPTION
Currently only read only and only displays the current system prompt.

Will do a refactor to keep tool registry & system prompt in global state that we can modify in the dialog in the future.

button in the chat:
<img width="846" height="309" alt="Screenshot 2025-07-25 at 12 42 20" src="https://github.com/user-attachments/assets/3d5d216f-052a-40ac-a005-9b6c5cce155c" />